### PR TITLE
Ensure predecessors are meters when picking fallback components

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- This fixes a bug in a rare case where the grid component could get picked as a fallback component.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,16 @@
 
 ## Summary
 
-This is the first release of the Frequenz Component Graph.  In this version, it supports validating component graphs, provides formula generators for various metrics and methods for manual traversal of the graph, when necessary.
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -150,15 +150,24 @@ where
             )));
         }
 
-        for sibling in siblings {
-            component_ids.remove(&sibling.component_id());
-        }
-
+        // Collect predecessor meter ids.
         let predecessor_ids: BTreeSet<u64> = self
             .graph
             .predecessors(component_id)?
+            .filter(|x| x.is_meter())
             .map(|x| x.component_id())
             .collect();
+
+        if predecessor_ids.is_empty() {
+            return Ok(Some(Expr::coalesce(
+                Expr::component(component_id),
+                Expr::number(0.0),
+            )));
+        }
+
+        for sibling in siblings {
+            component_ids.remove(&sibling.component_id());
+        }
 
         Ok(Some(self.generate(predecessor_ids)?))
     }
@@ -300,5 +309,27 @@ mod tests {
         assert_eq!(expr.to_string(), "COALESCE(#7, 0.0) + COALESCE(#14, 0.0)");
 
         Ok(())
+    }
+
+    /// Test fallback expression generation when there are no meters in the
+    /// graph, with only PV inverters directly connected to the grid.
+    #[test]
+    fn test_no_meters() {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+
+        let inverter = builder.solar_inverter();
+        builder.connect(grid, inverter);
+
+        let graph = builder.build(None).unwrap();
+        let expr = graph.pv_formula(None).unwrap().to_string();
+        assert_eq!(expr, "COALESCE(#1, 0.0)");
+
+        let inverter = builder.solar_inverter();
+        builder.connect(grid, inverter);
+
+        let graph = builder.build(None).unwrap();
+        let expr = graph.pv_formula(None).unwrap().to_string();
+        assert_eq!(expr, "COALESCE(#1, 0.0) + COALESCE(#2, 0.0)");
     }
 }


### PR DESCRIPTION
Without this, in some edge cases, where there are no meters, the grid component gets picked, which is incorrect.