### PR TITLE
Don't add any dist files when creating a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,7 @@ jobs:
             --notes-file RELEASE_NOTES.md \
             --generate-notes \
             $extra_opts \
-            $REF_NAME \
-            dist/*
+            $REF_NAME
         env:
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
This library is only distributed through crates.io.