### PR TITLE
Allow falling back to single successor meters in grid formulas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 # Frequenz Component Graph Release Notes
 
-## Bug Fixes
+## New Features
 
-- This fixes a bug in a rare case where the grid component could get picked as a fallback component.
+- Grid formulas now use single successor meters as fallback components for meters attached to the grid.

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -20,9 +20,11 @@ where
         &self,
         component_ids: impl IntoIterator<Item = u64>,
         prefer_meters: bool,
+        meter_fallback_for_meters: bool,
     ) -> Result<Expr, Error> {
         FallbackExpr {
             prefer_meters,
+            meter_fallback_for_meters,
             graph: self,
         }
         .generate(BTreeSet::from_iter(component_ids))
@@ -35,6 +37,7 @@ where
     E: Edge,
 {
     pub(crate) prefer_meters: bool,
+    pub(crate) meter_fallback_for_meters: bool,
     pub(crate) graph: &'a ComponentGraph<N, E>,
 }
 
@@ -67,8 +70,13 @@ where
     /// Returns a fallback expression for a meter component.
     fn meter_fallback(&self, component_id: u64) -> Result<Option<Expr>, Error> {
         let component = self.graph.component(component_id)?;
-        if !component.is_meter() || self.graph.has_meter_successors(component_id)? {
+        if !component.is_meter() {
             return Ok(None);
+        }
+        let has_successor_meters = self.graph.has_meter_successors(component_id)?;
+
+        if !self.meter_fallback_for_meters && has_successor_meters {
+            return Ok(Some(Expr::component(component_id)));
         }
 
         if !self.graph.has_successors(component_id)? {
@@ -91,6 +99,13 @@ where
 
         let has_multiple_successors = matches!(sum_of_successors, Expr::Add { .. });
 
+        // If a meter has exactly one successor and it is a meter, we consider
+        // it to be a fallback meter.  If there are multiple meter successors,
+        // we return the meter without fallback.
+        if has_successor_meters && has_multiple_successors {
+            return Ok(Some(Expr::component(component_id)));
+        }
+
         let mut coalesced = Expr::component(component_id);
 
         if !self.prefer_meters {
@@ -102,11 +117,13 @@ where
                 coalesced = coalesced.coalesce(sum_of_coalesced_successors);
             } else {
                 coalesced = coalesced.coalesce(sum_of_successors);
-                coalesced = coalesced.coalesce(Expr::number(0.0));
+                if !has_successor_meters {
+                    coalesced = coalesced.coalesce(Expr::number(0.0));
+                }
             }
         } else if has_multiple_successors {
             coalesced = coalesced.coalesce(sum_of_coalesced_successors);
-        } else {
+        } else if !has_successor_meters {
             coalesced = coalesced.coalesce(Expr::number(0.0));
         }
 
@@ -202,26 +219,36 @@ mod tests {
         assert_eq!(meter_bat_chain.component_id(), 2);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![1, 2], false)?;
+        let expr = graph.fallback_expr(vec![1], true, true)?;
+        assert_eq!(expr.to_string(), "COALESCE(#1, #2)");
+
+        let expr = graph.fallback_expr(vec![1, 2], true, true)?;
+        assert_eq!(expr.to_string(), "COALESCE(#1, #2) + COALESCE(#2, #3, 0.0)");
+
+        let expr = graph.fallback_expr(vec![1, 2], false, false)?;
         assert_eq!(expr.to_string(), "#1 + COALESCE(#3, #2, 0.0)");
 
-        let expr = graph.fallback_expr(vec![1, 2], true)?;
+        let expr = graph.fallback_expr(vec![1, 2], true, false)?;
         assert_eq!(expr.to_string(), "#1 + COALESCE(#2, #3, 0.0)");
 
-        let expr = graph.fallback_expr(vec![3], true)?;
+        let expr = graph.fallback_expr(vec![3], true, false)?;
+        assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
+        let expr = graph.fallback_expr(vec![3], true, true)?;
+        assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
+        let expr = graph.fallback_expr(vec![2], true, true)?;
         assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
 
         let graph = builder.build(Some(ComponentGraphConfig {
             disable_fallback_components: true,
             ..Default::default()
         }))?;
-        let expr = graph.fallback_expr(vec![1, 2], false)?;
+        let expr = graph.fallback_expr(vec![1, 2], false, false)?;
         assert_eq!(expr.to_string(), "#1 + #2");
 
-        let expr = graph.fallback_expr(vec![1, 2], true)?;
+        let expr = graph.fallback_expr(vec![1, 2], true, false)?;
         assert_eq!(expr.to_string(), "#1 + #2");
 
-        let expr = graph.fallback_expr(vec![3], true)?;
+        let expr = graph.fallback_expr(vec![3], true, false)?;
         assert_eq!(expr.to_string(), "#3");
 
         // Add a battery meter with three inverter and three batteries
@@ -231,7 +258,7 @@ mod tests {
         assert_eq!(meter_bat_chain.component_id(), 5);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![3, 5], false)?;
+        let expr = graph.fallback_expr(vec![3, 5], false, false)?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -244,7 +271,7 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 5], true)?;
+        let expr = graph.fallback_expr(vec![2, 5], true, false)?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -253,7 +280,7 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true)?;
+        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true, false)?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -262,7 +289,7 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 7, 8], true)?;
+        let expr = graph.fallback_expr(vec![2, 7, 8], true, false)?;
         assert_eq!(
             expr.to_string(),
             "COALESCE(#2, #3, 0.0) + COALESCE(#7, 0.0) + COALESCE(#8, 0.0)"
@@ -272,16 +299,16 @@ mod tests {
             disable_fallback_components: true,
             ..Default::default()
         }))?;
-        let expr = graph.fallback_expr(vec![3, 5], false)?;
+        let expr = graph.fallback_expr(vec![3, 5], false, false)?;
         assert_eq!(expr.to_string(), "#3 + #5");
 
-        let expr = graph.fallback_expr(vec![2, 5], true)?;
+        let expr = graph.fallback_expr(vec![2, 5], true, false)?;
         assert_eq!(expr.to_string(), "#2 + #5");
 
-        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true)?;
+        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true, false)?;
         assert_eq!(expr.to_string(), "#2 + #6 + #7 + #8");
 
-        let expr = graph.fallback_expr(vec![2, 7, 8], true)?;
+        let expr = graph.fallback_expr(vec![2, 7, 8], true, false)?;
         assert_eq!(expr.to_string(), "#2 + #7 + #8");
 
         let meter = builder.meter();
@@ -296,7 +323,7 @@ mod tests {
         assert_eq!(pv_inverter.component_id(), 14);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![5, 12], true)?;
+        let expr = graph.fallback_expr(vec![5, 12], true, false)?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -305,7 +332,7 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![7, 14], false)?;
+        let expr = graph.fallback_expr(vec![7, 14], false, false)?;
         assert_eq!(expr.to_string(), "COALESCE(#7, 0.0) + COALESCE(#14, 0.0)");
 
         Ok(())

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -9,27 +9,6 @@ use std::collections::BTreeSet;
 
 use super::expr::Expr;
 
-impl<N, E> ComponentGraph<N, E>
-where
-    N: Node,
-    E: Edge,
-{
-    /// Returns a formula expression with fallbacks where possible for the `sum`
-    /// of the given component ids.
-    pub(super) fn fallback_expr(
-        &self,
-        component_ids: impl IntoIterator<Item = u64>,
-        prefer_meters: bool,
-        meter_fallback_for_meters: bool,
-    ) -> Result<Expr, Error> {
-        FallbackExpr {
-            prefer_meters,
-            meter_fallback_for_meters,
-        }
-        .generate(self, BTreeSet::from_iter(component_ids))
-    }
-}
-
 pub(crate) struct FallbackExpr {
     pub(crate) prefer_meters: bool,
     pub(crate) meter_fallback_for_meters: bool,

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -25,39 +25,35 @@ where
         FallbackExpr {
             prefer_meters,
             meter_fallback_for_meters,
-            graph: self,
         }
-        .generate(BTreeSet::from_iter(component_ids))
+        .generate(self, BTreeSet::from_iter(component_ids))
     }
 }
 
-struct FallbackExpr<'a, N, E>
-where
-    N: Node,
-    E: Edge,
-{
+struct FallbackExpr {
     pub(crate) prefer_meters: bool,
     pub(crate) meter_fallback_for_meters: bool,
-    pub(crate) graph: &'a ComponentGraph<N, E>,
 }
 
-impl<N, E> FallbackExpr<'_, N, E>
-where
-    N: Node,
-    E: Edge,
-{
-    fn generate(&self, mut component_ids: BTreeSet<u64>) -> Result<Expr, Error> {
+impl FallbackExpr {
+    fn generate<N: Node, E: Edge>(
+        &self,
+        graph: &ComponentGraph<N, E>,
+        mut component_ids: BTreeSet<u64>,
+    ) -> Result<Expr, Error> {
         let mut formula = None::<Expr>;
-        if self.graph.config.disable_fallback_components {
+        if graph.config.disable_fallback_components {
             while let Some(component_id) = component_ids.pop_first() {
                 formula = Self::add_to_option(formula, Expr::component(component_id));
             }
             return formula.ok_or(Error::internal("No components to generate formula."));
         }
         while let Some(component_id) = component_ids.pop_first() {
-            if let Some(expr) = self.meter_fallback(component_id)? {
+            if let Some(expr) = self.meter_fallback(graph, component_id)? {
                 formula = Self::add_to_option(formula, expr);
-            } else if let Some(expr) = self.component_fallback(&mut component_ids, component_id)? {
+            } else if let Some(expr) =
+                self.component_fallback(graph, &mut component_ids, component_id)?
+            {
                 formula = Self::add_to_option(formula, expr);
             } else {
                 formula = Self::add_to_option(formula, Expr::component(component_id));
@@ -68,23 +64,26 @@ where
     }
 
     /// Returns a fallback expression for a meter component.
-    fn meter_fallback(&self, component_id: u64) -> Result<Option<Expr>, Error> {
-        let component = self.graph.component(component_id)?;
+    fn meter_fallback<N: Node, E: Edge>(
+        &self,
+        graph: &ComponentGraph<N, E>,
+        component_id: u64,
+    ) -> Result<Option<Expr>, Error> {
+        let component = graph.component(component_id)?;
         if !component.is_meter() {
             return Ok(None);
         }
-        let has_successor_meters = self.graph.has_meter_successors(component_id)?;
+        let has_successor_meters = graph.has_meter_successors(component_id)?;
 
         if !self.meter_fallback_for_meters && has_successor_meters {
             return Ok(Some(Expr::component(component_id)));
         }
 
-        if !self.graph.has_successors(component_id)? {
+        if !graph.has_successors(component_id)? {
             return Ok(Some(Expr::component(component_id)));
         }
 
-        let (sum_of_successors, sum_of_coalesced_successors) = self
-            .graph
+        let (sum_of_successors, sum_of_coalesced_successors) = graph
             .successors(component_id)?
             .map(|node| {
                 (
@@ -136,13 +135,14 @@ where
     /// - Battery Inverter
     /// - PV Inverter
     /// - EV Charger
-    fn component_fallback(
+    fn component_fallback<N: Node, E: Edge>(
         &self,
+        graph: &ComponentGraph<N, E>,
         component_ids: &mut BTreeSet<u64>,
         component_id: u64,
     ) -> Result<Option<Expr>, Error> {
-        let component = self.graph.component(component_id)?;
-        if !component.is_battery_inverter(&self.graph.config)
+        let component = graph.component(component_id)?;
+        if !component.is_battery_inverter(&graph.config)
             && !component.is_chp()
             && !component.is_pv_inverter()
             && !component.is_ev_charger()
@@ -152,8 +152,7 @@ where
 
         // If predecessors have other successors that are not in the list of
         // component ids, the predecessors can't be used as fallback.
-        let siblings = self
-            .graph
+        let siblings = graph
             .siblings_from_predecessors(component_id)?
             .filter(|sibling| sibling.component_id() != component_id)
             .collect::<Vec<_>>();
@@ -168,8 +167,7 @@ where
         }
 
         // Collect predecessor meter ids.
-        let predecessor_ids: BTreeSet<u64> = self
-            .graph
+        let predecessor_ids: BTreeSet<u64> = graph
             .predecessors(component_id)?
             .filter(|x| x.is_meter())
             .map(|x| x.component_id())
@@ -186,7 +184,7 @@ where
             component_ids.remove(&sibling.component_id());
         }
 
-        Ok(Some(self.generate(predecessor_ids)?))
+        Ok(Some(self.generate(graph, predecessor_ids)?))
     }
 
     fn add_to_option(expr: Option<Expr>, other: Expr) -> Option<Expr> {

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -30,13 +30,13 @@ where
     }
 }
 
-struct FallbackExpr {
+pub(crate) struct FallbackExpr {
     pub(crate) prefer_meters: bool,
     pub(crate) meter_fallback_for_meters: bool,
 }
 
 impl FallbackExpr {
-    fn generate<N: Node, E: Edge>(
+    pub(crate) fn generate<N: Node, E: Edge>(
         &self,
         graph: &ComponentGraph<N, E>,
         mut component_ids: BTreeSet<u64>,
@@ -198,7 +198,12 @@ impl FallbackExpr {
 
 #[cfg(test)]
 mod tests {
-    use crate::{graph::test_utils::ComponentGraphBuilder, ComponentGraphConfig, Error};
+    use std::collections::BTreeSet;
+
+    use crate::{
+        graph::{formulas::fallback::FallbackExpr, test_utils::ComponentGraphBuilder},
+        ComponentGraphConfig, Error,
+    };
 
     #[test]
     fn test_meter_fallback() -> Result<(), Error> {
@@ -217,36 +222,76 @@ mod tests {
         assert_eq!(meter_bat_chain.component_id(), 2);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![1], true, true)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: true,
+        }
+        .generate(&graph, BTreeSet::from([1]))?;
         assert_eq!(expr.to_string(), "COALESCE(#1, #2)");
 
-        let expr = graph.fallback_expr(vec![1, 2], true, true)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: true,
+        }
+        .generate(&graph, BTreeSet::from([1, 2]))?;
         assert_eq!(expr.to_string(), "COALESCE(#1, #2) + COALESCE(#2, #3, 0.0)");
 
-        let expr = graph.fallback_expr(vec![1, 2], false, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([1, 2]))?;
         assert_eq!(expr.to_string(), "#1 + COALESCE(#3, #2, 0.0)");
 
-        let expr = graph.fallback_expr(vec![1, 2], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([1, 2]))?;
         assert_eq!(expr.to_string(), "#1 + COALESCE(#2, #3, 0.0)");
 
-        let expr = graph.fallback_expr(vec![3], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([3]))?;
         assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
-        let expr = graph.fallback_expr(vec![3], true, true)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: true,
+        }
+        .generate(&graph, BTreeSet::from([3]))?;
         assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
-        let expr = graph.fallback_expr(vec![2], true, true)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: true,
+        }
+        .generate(&graph, BTreeSet::from([2]))?;
         assert_eq!(expr.to_string(), "COALESCE(#2, #3, 0.0)");
 
         let graph = builder.build(Some(ComponentGraphConfig {
             disable_fallback_components: true,
             ..Default::default()
         }))?;
-        let expr = graph.fallback_expr(vec![1, 2], false, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([1, 2]))?;
         assert_eq!(expr.to_string(), "#1 + #2");
 
-        let expr = graph.fallback_expr(vec![1, 2], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([1, 2]))?;
         assert_eq!(expr.to_string(), "#1 + #2");
 
-        let expr = graph.fallback_expr(vec![3], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([3]))?;
         assert_eq!(expr.to_string(), "#3");
 
         // Add a battery meter with three inverter and three batteries
@@ -256,7 +301,11 @@ mod tests {
         assert_eq!(meter_bat_chain.component_id(), 5);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![3, 5], false, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([3, 5]))?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -269,7 +318,11 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 5], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 5]))?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -278,7 +331,11 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 6, 7, 8]))?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -287,7 +344,11 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![2, 7, 8], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 7, 8]))?;
         assert_eq!(
             expr.to_string(),
             "COALESCE(#2, #3, 0.0) + COALESCE(#7, 0.0) + COALESCE(#8, 0.0)"
@@ -297,16 +358,32 @@ mod tests {
             disable_fallback_components: true,
             ..Default::default()
         }))?;
-        let expr = graph.fallback_expr(vec![3, 5], false, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([3, 5]))?;
         assert_eq!(expr.to_string(), "#3 + #5");
 
-        let expr = graph.fallback_expr(vec![2, 5], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 5]))?;
         assert_eq!(expr.to_string(), "#2 + #5");
 
-        let expr = graph.fallback_expr(vec![2, 6, 7, 8], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 6, 7, 8]))?;
         assert_eq!(expr.to_string(), "#2 + #6 + #7 + #8");
 
-        let expr = graph.fallback_expr(vec![2, 7, 8], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([2, 7, 8]))?;
         assert_eq!(expr.to_string(), "#2 + #7 + #8");
 
         let meter = builder.meter();
@@ -321,7 +398,11 @@ mod tests {
         assert_eq!(pv_inverter.component_id(), 14);
 
         let graph = builder.build(None)?;
-        let expr = graph.fallback_expr(vec![5, 12], true, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: true,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([5, 12]))?;
         assert_eq!(
             expr.to_string(),
             concat!(
@@ -330,7 +411,11 @@ mod tests {
             )
         );
 
-        let expr = graph.fallback_expr(vec![7, 14], false, false)?;
+        let expr = FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(&graph, BTreeSet::from([7, 14]))?;
         assert_eq!(expr.to_string(), "COALESCE(#7, 0.0) + COALESCE(#14, 0.0)");
 
         Ok(())

--- a/src/graph/formulas/generators/battery.rs
+++ b/src/graph/formulas/generators/battery.rs
@@ -55,7 +55,7 @@ where
         }
 
         self.graph
-            .fallback_expr(self.inverter_ids, false)
+            .fallback_expr(self.inverter_ids, false, false)
             .map(AggregationFormula::new)
     }
 

--- a/src/graph/formulas/generators/battery.rs
+++ b/src/graph/formulas/generators/battery.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::component_category::CategoryPredicates;
 use crate::graph::formulas::expr::Expr;
+use crate::graph::formulas::fallback::FallbackExpr;
 use crate::graph::formulas::AggregationFormula;
 use crate::{ComponentGraph, Edge, Error, Node};
 
@@ -54,9 +55,12 @@ where
             return Ok(AggregationFormula::new(Expr::number(0.0)));
         }
 
-        self.graph
-            .fallback_expr(self.inverter_ids, false, false)
-            .map(AggregationFormula::new)
+        FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(self.graph, self.inverter_ids.clone())
+        .map(AggregationFormula::new)
     }
 
     pub(super) fn find_inverter_ids(

--- a/src/graph/formulas/generators/chp.rs
+++ b/src/graph/formulas/generators/chp.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::component_category::CategoryPredicates;
 use crate::graph::formulas::expr::Expr;
+use crate::graph::formulas::fallback::FallbackExpr;
 use crate::graph::formulas::AggregationFormula;
 use crate::{ComponentGraph, Edge, Error, Node};
 
@@ -58,9 +59,12 @@ where
             }
         }
 
-        self.graph
-            .fallback_expr(self.chp_ids, false, false)
-            .map(AggregationFormula::new)
+        FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(self.graph, self.chp_ids.clone())
+        .map(AggregationFormula::new)
     }
 }
 

--- a/src/graph/formulas/generators/chp.rs
+++ b/src/graph/formulas/generators/chp.rs
@@ -59,7 +59,7 @@ where
         }
 
         self.graph
-            .fallback_expr(self.chp_ids, false)
+            .fallback_expr(self.chp_ids, false, false)
             .map(AggregationFormula::new)
     }
 }

--- a/src/graph/formulas/generators/consumer.rs
+++ b/src/graph/formulas/generators/consumer.rs
@@ -95,7 +95,7 @@ where
             // Subtract each successor from the expression.
             for successor in successors {
                 let successor_expr = if successor.1.is_meter() {
-                    self.graph.fallback_expr([successor.0], true)?
+                    self.graph.fallback_expr([successor.0], true, false)?
                 } else {
                     Expr::from(successor.1)
                 };

--- a/src/graph/formulas/generators/consumer.rs
+++ b/src/graph/formulas/generators/consumer.rs
@@ -7,8 +7,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use super::super::expr::Expr;
 use crate::{
-    component_category::CategoryPredicates, graph::formulas::AggregationFormula, ComponentGraph,
-    Edge, Error, Node,
+    component_category::CategoryPredicates,
+    graph::formulas::{fallback::FallbackExpr, AggregationFormula},
+    ComponentGraph, Edge, Error, Node,
 };
 
 pub(crate) struct ConsumerFormulaBuilder<'a, N, E>
@@ -95,7 +96,11 @@ where
             // Subtract each successor from the expression.
             for successor in successors {
                 let successor_expr = if successor.1.is_meter() {
-                    self.graph.fallback_expr([successor.0], true, false)?
+                    FallbackExpr {
+                        prefer_meters: true,
+                        meter_fallback_for_meters: false,
+                    }
+                    .generate(self.graph, BTreeSet::from([successor.0]))?
                 } else {
                     Expr::from(successor.1)
                 };

--- a/src/graph/formulas/generators/ev_charger.rs
+++ b/src/graph/formulas/generators/ev_charger.rs
@@ -62,7 +62,7 @@ where
         }
 
         self.graph
-            .fallback_expr(self.ev_charger_ids, false)
+            .fallback_expr(self.ev_charger_ids, false, false)
             .map(AggregationFormula::new)
     }
 }

--- a/src/graph/formulas/generators/ev_charger.rs
+++ b/src/graph/formulas/generators/ev_charger.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::component_category::CategoryPredicates;
 use crate::graph::formulas::expr::Expr;
+use crate::graph::formulas::fallback::FallbackExpr;
 use crate::graph::formulas::AggregationFormula;
 use crate::{ComponentGraph, Edge, Error, Node};
 
@@ -61,9 +62,12 @@ where
             }
         }
 
-        self.graph
-            .fallback_expr(self.ev_charger_ids, false, false)
-            .map(AggregationFormula::new)
+        FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(self.graph, self.ev_charger_ids.clone())
+        .map(AggregationFormula::new)
     }
 }
 

--- a/src/graph/formulas/generators/grid.rs
+++ b/src/graph/formulas/generators/grid.rs
@@ -33,7 +33,9 @@ where
     pub fn build(self) -> Result<AggregationFormula, Error> {
         let mut expr = None;
         for comp in self.graph.successors(self.graph.root_id)? {
-            let comp = self.graph.fallback_expr([comp.component_id()], true)?;
+            let comp = self
+                .graph
+                .fallback_expr([comp.component_id()], true, false)?;
             expr = match expr {
                 None => Some(comp),
                 Some(e) => Some(comp + e),

--- a/src/graph/formulas/generators/grid.rs
+++ b/src/graph/formulas/generators/grid.rs
@@ -35,7 +35,7 @@ where
         for comp in self.graph.successors(self.graph.root_id)? {
             let comp = self
                 .graph
-                .fallback_expr([comp.component_id()], true, false)?;
+                .fallback_expr([comp.component_id()], true, true)?;
             expr = match expr {
                 None => Some(comp),
                 Some(e) => Some(comp + e),
@@ -59,13 +59,18 @@ mod tests {
 
         // Add a grid meter and a battery chain behind it.
         let grid_meter = builder.meter();
-        let meter_bat_chain = builder.meter_bat_chain(1, 1);
         builder.connect(grid, grid_meter);
-        builder.connect(grid_meter, meter_bat_chain);
 
         let graph = builder.build(None)?;
         let formula = graph.grid_formula()?.to_string();
         assert_eq!(formula, "#1");
+
+        let meter_bat_chain = builder.meter_bat_chain(1, 1);
+        builder.connect(grid_meter, meter_bat_chain);
+
+        let graph = builder.build(None)?;
+        let formula = graph.grid_formula()?.to_string();
+        assert_eq!(formula, "COALESCE(#1, #2)");
 
         // Add an additional dangling meter, and a PV chain and a battery chain
         // to the grid
@@ -84,7 +89,7 @@ mod tests {
         let formula = graph.grid_formula()?.to_string();
         assert_eq!(
             formula,
-            "#1 + #5 + COALESCE(#6, #7, 0.0) + COALESCE(#9, #10, 0.0)"
+            "COALESCE(#1, #2) + #5 + COALESCE(#6, #7, 0.0) + COALESCE(#9, #10, 0.0)"
         );
 
         // Add a PV inverter to the grid, without a meter.
@@ -97,7 +102,7 @@ mod tests {
         let formula = graph.grid_formula()?.to_string();
         assert_eq!(
             formula,
-            "#1 + #5 + COALESCE(#6, #7, 0.0) + COALESCE(#9, #10, 0.0) + COALESCE(#11, 0.0)"
+            "COALESCE(#1, #2) + #5 + COALESCE(#6, #7, 0.0) + COALESCE(#9, #10, 0.0) + COALESCE(#11, 0.0)"
         );
 
         Ok(())

--- a/src/graph/formulas/generators/grid.rs
+++ b/src/graph/formulas/generators/grid.rs
@@ -3,8 +3,10 @@
 
 //! This module contains the methods for generating grid formulas.
 
+use std::collections::BTreeSet;
+
 use crate::{
-    graph::formulas::{expr::Expr, AggregationFormula},
+    graph::formulas::{expr::Expr, fallback::FallbackExpr, AggregationFormula},
     ComponentGraph, Edge, Error, Node,
 };
 
@@ -33,9 +35,11 @@ where
     pub fn build(self) -> Result<AggregationFormula, Error> {
         let mut expr = None;
         for comp in self.graph.successors(self.graph.root_id)? {
-            let comp = self
-                .graph
-                .fallback_expr([comp.component_id()], true, true)?;
+            let comp = FallbackExpr {
+                prefer_meters: true,
+                meter_fallback_for_meters: true,
+            }
+            .generate(self.graph, BTreeSet::from([comp.component_id()]))?;
             expr = match expr {
                 None => Some(comp),
                 Some(e) => Some(comp + e),

--- a/src/graph/formulas/generators/producer.rs
+++ b/src/graph/formulas/generators/producer.rs
@@ -47,7 +47,7 @@ where
         )? {
             let comp_expr = self
                 .graph
-                .fallback_expr([component_id], false)?
+                .fallback_expr([component_id], false, false)?
                 .min(Expr::number(0.0));
             expr = match expr {
                 None => Some(comp_expr),

--- a/src/graph/formulas/generators/producer.rs
+++ b/src/graph/formulas/generators/producer.rs
@@ -3,8 +3,11 @@
 
 //! This module contains the methods for generating producer formulas.
 
+use std::collections::BTreeSet;
+
 use super::super::expr::Expr;
 use crate::component_category::CategoryPredicates;
+use crate::graph::formulas::fallback::FallbackExpr;
 use crate::graph::formulas::AggregationFormula;
 use crate::{ComponentGraph, Edge, Error, Node};
 
@@ -45,10 +48,12 @@ where
             petgraph::Direction::Outgoing,
             false,
         )? {
-            let comp_expr = self
-                .graph
-                .fallback_expr([component_id], false, false)?
-                .min(Expr::number(0.0));
+            let comp_expr = FallbackExpr {
+                prefer_meters: false,
+                meter_fallback_for_meters: false,
+            }
+            .generate(self.graph, BTreeSet::from([component_id]))?
+            .min(Expr::number(0.0));
             expr = match expr {
                 None => Some(comp_expr),
                 Some(e) => Some(e + comp_expr),

--- a/src/graph/formulas/generators/pv.rs
+++ b/src/graph/formulas/generators/pv.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::component_category::CategoryPredicates;
 use crate::graph::formulas::expr::Expr;
+use crate::graph::formulas::fallback::FallbackExpr;
 use crate::graph::formulas::AggregationFormula;
 use crate::{ComponentGraph, Edge, Error, Node};
 
@@ -61,9 +62,12 @@ where
             }
         }
 
-        self.graph
-            .fallback_expr(self.pv_inverter_ids, false, false)
-            .map(AggregationFormula::new)
+        FallbackExpr {
+            prefer_meters: false,
+            meter_fallback_for_meters: false,
+        }
+        .generate(self.graph, self.pv_inverter_ids.clone())
+        .map(AggregationFormula::new)
     }
 }
 

--- a/src/graph/formulas/generators/pv.rs
+++ b/src/graph/formulas/generators/pv.rs
@@ -62,7 +62,7 @@ where
         }
 
         self.graph
-            .fallback_expr(self.pv_inverter_ids, false)
+            .fallback_expr(self.pv_inverter_ids, false, false)
             .map(AggregationFormula::new)
     }
 }


### PR DESCRIPTION
With this, grid meters that have a single meter connected to them can use that meter as a fallback component.