### PR TITLE
Treat untracked component categories as transparent pass-throughs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `predecessors` / `successors` now walk past pass-through (untracked) component categories (`Converter`, `Breaker`, `Precharger`, `Electrolyzer`, `PowerTransformer`, `Hvac`, `Plc`, `CryptoMiner`, `StaticTransferSwitch`, `UninterruptiblePowerSupply`, `CapacitorBank`), making them transparent to formula generation and neighbor-rule validation. Use the new `raw_predecessors` / `raw_successors` if you need the literal graph-direct view that includes them.
 
 ## New Features
 

--- a/src/component_category.rs
+++ b/src/component_category.rs
@@ -126,6 +126,41 @@ impl Display for ComponentCategory {
     }
 }
 
+impl ComponentCategory {
+    /// Returns `true` if this category is a *pass-through*: a component
+    /// that has no specific handling in the graph and should be treated
+    /// as transparent by validators and formula generators.
+    ///
+    /// Pass-through nodes can sit anywhere in the chain between handled
+    /// categories. They don't generate or consume their own measurement,
+    /// and neighbor relationships across them are evaluated by walking
+    /// past them as if they weren't present.
+    ///
+    /// `Unspecified` is intentionally not a pass-through: it's rejected
+    /// at graph-construction time before validators or formula
+    /// generators ever see it.
+    // Consumed by the pass-through-aware `predecessors`/`successors` and
+    // the construction-time warning in subsequent commits.
+    #[allow(dead_code)]
+    pub(crate) fn is_passthrough(self) -> bool {
+        use ComponentCategory as C;
+        matches!(
+            self,
+            C::Converter
+                | C::Breaker
+                | C::Precharger
+                | C::Electrolyzer
+                | C::PowerTransformer
+                | C::Hvac
+                | C::Plc
+                | C::CryptoMiner
+                | C::StaticTransferSwitch
+                | C::UninterruptiblePowerSupply
+                | C::CapacitorBank
+        )
+    }
+}
+
 /// Predicates for checking the component category of a `Node`.
 pub(crate) trait CategoryPredicates: Node {
     fn is_unspecified(&self) -> bool {
@@ -195,3 +230,54 @@ pub(crate) trait CategoryPredicates: Node {
 /// Implement the `CategoryPredicates` trait for all types that implement the
 /// `Node` trait.
 impl<T: Node> CategoryPredicates for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks the pass-through classification. If a category is added or
+    /// re-classified, this test forces an explicit decision rather than
+    /// silently inheriting the default.
+    #[test]
+    fn test_is_passthrough_classification() {
+        // Pass-through categories: no specific validation rule, no formula
+        // contribution; transparent to traversal.
+        for c in [
+            ComponentCategory::Converter,
+            ComponentCategory::Breaker,
+            ComponentCategory::Precharger,
+            ComponentCategory::Electrolyzer,
+            ComponentCategory::PowerTransformer,
+            ComponentCategory::Hvac,
+            ComponentCategory::Plc,
+            ComponentCategory::CryptoMiner,
+            ComponentCategory::StaticTransferSwitch,
+            ComponentCategory::UninterruptiblePowerSupply,
+            ComponentCategory::CapacitorBank,
+        ] {
+            assert!(c.is_passthrough(), "{c} should be a pass-through");
+        }
+
+        // Handled or special-cased categories.
+        for c in [
+            ComponentCategory::Unspecified,
+            ComponentCategory::GridConnectionPoint,
+            ComponentCategory::Meter,
+            ComponentCategory::Inverter(InverterType::Battery),
+            ComponentCategory::Inverter(InverterType::Pv),
+            ComponentCategory::Inverter(InverterType::Hybrid),
+            ComponentCategory::Inverter(InverterType::Unspecified),
+            ComponentCategory::Battery(BatteryType::LiIon),
+            ComponentCategory::Battery(BatteryType::NaIon),
+            ComponentCategory::Battery(BatteryType::Unspecified),
+            ComponentCategory::EvCharger(EvChargerType::Ac),
+            ComponentCategory::EvCharger(EvChargerType::Dc),
+            ComponentCategory::EvCharger(EvChargerType::Hybrid),
+            ComponentCategory::EvCharger(EvChargerType::Unspecified),
+            ComponentCategory::Chp,
+            ComponentCategory::WindTurbine,
+        ] {
+            assert!(!c.is_passthrough(), "{c} should not be a pass-through");
+        }
+    }
+}

--- a/src/component_category.rs
+++ b/src/component_category.rs
@@ -139,9 +139,6 @@ impl ComponentCategory {
     /// `Unspecified` is intentionally not a pass-through: it's rejected
     /// at graph-construction time before validators or formula
     /// generators ever see it.
-    // Consumed by the pass-through-aware `predecessors`/`successors` and
-    // the construction-time warning in subsequent commits.
-    #[allow(dead_code)]
     pub(crate) fn is_passthrough(self) -> bool {
         use ComponentCategory as C;
         matches!(

--- a/src/graph/creation.rs
+++ b/src/graph/creation.rs
@@ -38,6 +38,21 @@ where
 
         cg.validate()?;
 
+        // Notify operators that any pass-through nodes in the graph
+        // will be treated as transparent by validators and formula
+        // generators. Logged once per node, after validation, so we
+        // only warn for components that actually end up in the graph.
+        for component in cg.components() {
+            if component.category().is_passthrough() {
+                tracing::warn!(
+                    "Component {cid} ({category}) is a pass-through category and \
+                     will be treated as transparent in validators and formula generators.",
+                    cid = component.component_id(),
+                    category = component.category(),
+                );
+            }
+        }
+
         Ok(cg)
     }
 

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -412,6 +412,194 @@ mod tests {
         assert_eq!(expr, "COALESCE(#1, 0.0) + COALESCE(#2, 0.0)");
     }
 
+    // ---------------------------------------------------------------
+    // Pass-through scenarios.
+    //
+    // These tests document the *desired* behavior when a component
+    // category that has no specific handling (here: `PowerTransformer`)
+    // sits in the topology. Validators and the formula generator
+    // should treat such a node as transparent — walking through it
+    // instead of rejecting otherwise-valid neighbor relationships or
+    // emitting it as a measurement source.
+    //
+    // Each test is `#[ignore]` until the corresponding fix lands;
+    // `cargo test -- --ignored` reproduces today's incorrect output.
+    // ---------------------------------------------------------------
+
+    /// Validation accepts a graph where a pass-through category sits
+    /// between an inverter and its meter / between a meter and the
+    /// grid. Neighbor rules (`M1`, `I1-I4`, `B1`) consult the
+    /// effective predecessors / successors, so the chain through the
+    /// pass-through reads as if it weren't there.
+    ///
+    /// Topology: `Grid → PowerTransformer → Meter → BatteryInverter → Battery`
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_validation_accepts_passthrough_predecessor() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let pt = builder.power_transformer();
+        let meter = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, pt);
+        builder.connect(pt, meter);
+        builder.connect(meter, inverter);
+        builder.connect(inverter, battery);
+
+        // Should build cleanly with the default config.
+        let _graph = builder.build(None)?;
+        Ok(())
+    }
+
+    /// A pass-through-only cycle attached to an otherwise-valid graph
+    /// is rejected at construction time. The acyclicity validator
+    /// walks the raw graph so cycles composed entirely of pass-through
+    /// nodes are still detected.
+    ///
+    /// Topology: a normal `Grid → Meter → BatteryInverter → Battery`
+    /// branch, plus a side-branch `Grid → PT1 → PT2 → PT3 → PT1` cycle.
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_acyclicity_detects_passthrough_only_cycle() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let meter = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+        let pt1 = builder.power_transformer();
+        let pt2 = builder.power_transformer();
+        let pt3 = builder.power_transformer();
+
+        builder.connect(grid, meter);
+        builder.connect(meter, inverter);
+        builder.connect(inverter, battery);
+
+        builder.connect(grid, pt1);
+        builder.connect(pt1, pt2);
+        builder.connect(pt2, pt3);
+        builder.connect(pt3, pt1);
+
+        assert!(
+            builder.build(None).is_err(),
+            "PT-only cycle reachable from the GCP must be detected at construction time"
+        );
+        Ok(())
+    }
+
+    /// A pass-through component preceding the GCP is tolerated: the
+    /// effective predecessors view walks past it, so `ensure_root` sees
+    /// no ancestor and accepts the GCP as a root.
+    ///
+    /// Topology: `PT → Grid → Meter → BatteryInverter → Battery`.
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_ensure_root_tolerates_passthrough_predecessor() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let pt = builder.power_transformer();
+        let meter = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(pt, grid);
+        builder.connect(grid, meter);
+        builder.connect(meter, inverter);
+        builder.connect(inverter, battery);
+
+        let _graph = builder.build(None)?;
+        Ok(())
+    }
+
+    /// Grid formula skips a PowerTransformer that sits directly below
+    /// the GCP and uses the meter beneath it as the measurement source
+    /// — the formula is identical to the equivalent
+    /// `Grid → Meter → Inverter → Battery` graph.
+    ///
+    /// Topology (component ids): `Grid:0 → PT:1 → Meter:2 → Inverter:3 → Battery:4`
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_grid_formula_skips_passthrough_at_root() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let pt = builder.power_transformer();
+        let meter = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, pt);
+        builder.connect(pt, meter);
+        builder.connect(meter, inverter);
+        builder.connect(inverter, battery);
+
+        let graph = builder.build(None)?;
+        let formula = graph.grid_formula()?.to_string();
+        assert!(
+            !formula.contains("#1"),
+            "PowerTransformer #1 must not appear in grid_formula, got {formula:?}",
+        );
+        assert_eq!(formula, "COALESCE(#2, #3, 0.0)");
+        Ok(())
+    }
+
+    /// Meter fallback sums the meter's *effective* successors —
+    /// walking past pass-throughs to the inverter rather than
+    /// including the transformer (which has no measurement).
+    ///
+    /// Topology (component ids): `Grid:0 → Meter:1 → PT:2 → Inverter:3 → Battery:4`
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_meter_fallback_skips_passthrough_successor() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let meter = builder.meter();
+        let pt = builder.power_transformer();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, meter);
+        builder.connect(meter, pt);
+        builder.connect(pt, inverter);
+        builder.connect(inverter, battery);
+
+        let graph = builder.build(None)?;
+        let formula = graph.grid_formula()?.to_string();
+        assert!(
+            !formula.contains("#2"),
+            "PowerTransformer #2 must not appear in grid_formula, got {formula:?}",
+        );
+        assert_eq!(formula, "COALESCE(#1, #3, 0.0)");
+        Ok(())
+    }
+
+    /// Component fallback must find a predecessor meter through a
+    /// pass-through node.
+    ///
+    /// Topology (component ids): `Grid:0 → Meter:1 → PT:2 → Inverter:3 → Battery:4`
+    #[test]
+    #[ignore = "fails today; pass-through transparency not yet implemented"]
+    fn test_component_fallback_finds_meter_through_passthrough() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let meter = builder.meter();
+        let pt = builder.power_transformer();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, meter);
+        builder.connect(meter, pt);
+        builder.connect(pt, inverter);
+        builder.connect(inverter, battery);
+
+        let graph = builder.build(None)?;
+        let formula = graph.battery_formula(None)?.to_string();
+        // Inverter falls back to its effective predecessor meter,
+        // walking past the transformer.
+        assert_eq!(formula, "COALESCE(#1, #3, 0.0)");
+        Ok(())
+    }
+
     /// Test meters with meter fallback
     #[test]
     fn test_meters_with_meter_fallback() -> Result<(), Error> {

--- a/src/graph/formulas/fallback.rs
+++ b/src/graph/formulas/fallback.rs
@@ -421,9 +421,6 @@ mod tests {
     // should treat such a node as transparent — walking through it
     // instead of rejecting otherwise-valid neighbor relationships or
     // emitting it as a measurement source.
-    //
-    // Each test is `#[ignore]` until the corresponding fix lands;
-    // `cargo test -- --ignored` reproduces today's incorrect output.
     // ---------------------------------------------------------------
 
     /// Validation accepts a graph where a pass-through category sits
@@ -434,7 +431,6 @@ mod tests {
     ///
     /// Topology: `Grid → PowerTransformer → Meter → BatteryInverter → Battery`
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_validation_accepts_passthrough_predecessor() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();
@@ -461,7 +457,6 @@ mod tests {
     /// Topology: a normal `Grid → Meter → BatteryInverter → Battery`
     /// branch, plus a side-branch `Grid → PT1 → PT2 → PT3 → PT1` cycle.
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_acyclicity_detects_passthrough_only_cycle() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();
@@ -494,7 +489,6 @@ mod tests {
     ///
     /// Topology: `PT → Grid → Meter → BatteryInverter → Battery`.
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_ensure_root_tolerates_passthrough_predecessor() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();
@@ -519,7 +513,6 @@ mod tests {
     ///
     /// Topology (component ids): `Grid:0 → PT:1 → Meter:2 → Inverter:3 → Battery:4`
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_grid_formula_skips_passthrough_at_root() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();
@@ -549,7 +542,6 @@ mod tests {
     ///
     /// Topology (component ids): `Grid:0 → Meter:1 → PT:2 → Inverter:3 → Battery:4`
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_meter_fallback_skips_passthrough_successor() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();
@@ -578,7 +570,6 @@ mod tests {
     ///
     /// Topology (component ids): `Grid:0 → Meter:1 → PT:2 → Inverter:3 → Battery:4`
     #[test]
-    #[ignore = "fails today; pass-through transparency not yet implemented"]
     fn test_component_fallback_finds_meter_through_passthrough() -> Result<(), Error> {
         let mut builder = ComponentGraphBuilder::new();
         let grid = builder.grid();

--- a/src/graph/formulas/generators/consumer.rs
+++ b/src/graph/formulas/generators/consumer.rs
@@ -401,7 +401,7 @@ mod tests {
             ..Default::default()
         }))?;
         let formula = graph_no_phantom.consumer_formula()?.to_string();
-        assert_eq!(formula, concat!("MAX(#1 - #2 - #5 - #8 - #9 - #10, 0.0)"));
+        assert_eq!(formula, "MAX(#1 - #2 - #5 - #8 - #9 - #10, 0.0)");
 
         // add a battery chain to the grid meter and a dangling meter to the grid.
         let meter_bat_chain = builder.meter_bat_chain(1, 1);

--- a/src/graph/iterators.rs
+++ b/src/graph/iterators.rs
@@ -76,13 +76,38 @@ where
     }
 }
 
+/// An iterator over the *effective* (pass-through-aware) neighbors of a
+/// component.
+///
+/// Returned by [`ComponentGraph::predecessors`] and
+/// [`ComponentGraph::successors`]. Yields only non-pass-through ancestors
+/// or descendants, walking transparently past pass-through nodes in the
+/// chain. Eagerly collected at construction time.
+pub struct Neighbors<'a, N>
+where
+    N: Node,
+{
+    pub(crate) iter: IntoIter<&'a N>,
+}
+
+impl<'a, N> Iterator for Neighbors<'a, N>
+where
+    N: Node,
+{
+    type Item = &'a N;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
 /// An iterator over the siblings of a component in a `ComponentGraph`.
 pub struct Siblings<'a, N>
 where
     N: Node,
 {
     pub(crate) component_id: u64,
-    pub(crate) iter: Flatten<IntoIter<RawNeighbors<'a, N>>>,
+    pub(crate) iter: Flatten<IntoIter<Neighbors<'a, N>>>,
     visited: HashSet<u64>,
 }
 
@@ -90,7 +115,7 @@ impl<'a, N> Siblings<'a, N>
 where
     N: Node,
 {
-    pub(crate) fn new(component_id: u64, iter: Flatten<IntoIter<RawNeighbors<'a, N>>>) -> Self {
+    pub(crate) fn new(component_id: u64, iter: Flatten<IntoIter<Neighbors<'a, N>>>) -> Self {
         Siblings {
             component_id,
             iter,

--- a/src/graph/iterators.rs
+++ b/src/graph/iterators.rs
@@ -52,8 +52,12 @@ where
     }
 }
 
-/// An iterator over the neighbors of a component in a `ComponentGraph`.
-pub struct Neighbors<'a, N>
+/// An iterator over the *raw* (graph-direct) neighbors of a component.
+///
+/// Returned by [`ComponentGraph::raw_predecessors`] and
+/// [`ComponentGraph::raw_successors`]. Yields every node connected by an
+/// edge, including pass-through categories.
+pub struct RawNeighbors<'a, N>
 where
     N: Node,
 {
@@ -61,7 +65,7 @@ where
     pub(crate) iter: petgraph::graph::Neighbors<'a, ()>,
 }
 
-impl<'a, N> Iterator for Neighbors<'a, N>
+impl<'a, N> Iterator for RawNeighbors<'a, N>
 where
     N: Node,
 {
@@ -78,7 +82,7 @@ where
     N: Node,
 {
     pub(crate) component_id: u64,
-    pub(crate) iter: Flatten<IntoIter<Neighbors<'a, N>>>,
+    pub(crate) iter: Flatten<IntoIter<RawNeighbors<'a, N>>>,
     visited: HashSet<u64>,
 }
 
@@ -86,7 +90,7 @@ impl<'a, N> Siblings<'a, N>
 where
     N: Node,
 {
-    pub(crate) fn new(component_id: u64, iter: Flatten<IntoIter<Neighbors<'a, N>>>) -> Self {
+    pub(crate) fn new(component_id: u64, iter: Flatten<IntoIter<RawNeighbors<'a, N>>>) -> Self {
         Siblings {
             component_id,
             iter,

--- a/src/graph/retrieval.rs
+++ b/src/graph/retrieval.rs
@@ -3,7 +3,7 @@
 
 //! Methods for retrieving components and connections from a [`ComponentGraph`].
 
-use crate::iterators::{Components, Connections, Neighbors, Siblings};
+use crate::iterators::{Components, Connections, RawNeighbors, Siblings};
 use crate::{ComponentGraph, Edge, Error, Node};
 use std::collections::BTreeSet;
 
@@ -38,14 +38,60 @@ where
         }
     }
 
+    /// Returns an iterator over the *raw* (graph-direct) predecessors of
+    /// the component with the given `component_id`.
+    ///
+    /// "Raw" means every node connected by an incoming edge, including
+    /// pass-through categories. Most callers want
+    /// [`predecessors`][Self::predecessors] instead, which walks past
+    /// pass-throughs transparently.
+    ///
+    /// Returns an error if the given `component_id` does not exist.
+    pub fn raw_predecessors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
+        self.node_indices
+            .get(&component_id)
+            .map(|&index| RawNeighbors {
+                graph: &self.graph,
+                iter: self
+                    .graph
+                    .neighbors_directed(index, petgraph::Direction::Incoming),
+            })
+            .ok_or_else(|| {
+                Error::component_not_found(format!("Component with id {component_id} not found."))
+            })
+    }
+
+    /// Returns an iterator over the *raw* (graph-direct) successors of
+    /// the component with the given `component_id`.
+    ///
+    /// "Raw" means every node connected by an outgoing edge, including
+    /// pass-through categories. Most callers want
+    /// [`successors`][Self::successors] instead, which walks past
+    /// pass-throughs transparently.
+    ///
+    /// Returns an error if the given `component_id` does not exist.
+    pub fn raw_successors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
+        self.node_indices
+            .get(&component_id)
+            .map(|&index| RawNeighbors {
+                graph: &self.graph,
+                iter: self
+                    .graph
+                    .neighbors_directed(index, petgraph::Direction::Outgoing),
+            })
+            .ok_or_else(|| {
+                Error::component_not_found(format!("Component with id {component_id} not found."))
+            })
+    }
+
     /// Returns an iterator over the *predecessors* of the component with the
     /// given `component_id`.
     ///
     /// Returns an error if the given `component_id` does not exist.
-    pub fn predecessors(&self, component_id: u64) -> Result<Neighbors<'_, N>, Error> {
+    pub fn predecessors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
         self.node_indices
             .get(&component_id)
-            .map(|&index| Neighbors {
+            .map(|&index| RawNeighbors {
                 graph: &self.graph,
                 iter: self
                     .graph
@@ -60,10 +106,10 @@ where
     /// given `component_id`.
     ///
     /// Returns an error if the given `component_id` does not exist.
-    pub fn successors(&self, component_id: u64) -> Result<Neighbors<'_, N>, Error> {
+    pub fn successors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
         self.node_indices
             .get(&component_id)
-            .map(|&index| Neighbors {
+            .map(|&index| RawNeighbors {
                 graph: &self.graph,
                 iter: self
                     .graph

--- a/src/graph/retrieval.rs
+++ b/src/graph/retrieval.rs
@@ -3,9 +3,10 @@
 
 //! Methods for retrieving components and connections from a [`ComponentGraph`].
 
-use crate::iterators::{Components, Connections, RawNeighbors, Siblings};
+use crate::iterators::{Components, Connections, Neighbors, RawNeighbors, Siblings};
 use crate::{ComponentGraph, Edge, Error, Node};
-use std::collections::BTreeSet;
+use petgraph::graph::NodeIndex;
+use std::collections::{BTreeSet, HashSet, VecDeque};
 
 /// `Component` and `Connection` retrieval.
 impl<N, E> ComponentGraph<N, E>
@@ -82,40 +83,65 @@ where
             })
     }
 
-    /// Returns an iterator over the *predecessors* of the component with the
-    /// given `component_id`.
+    /// Returns an iterator over the *predecessors* of the component with
+    /// the given `component_id`, walking transparently past pass-through
+    /// categories.
+    ///
+    /// Pass-through nodes are skipped: their non-pass-through ancestors
+    /// take their place in the iterator. For the raw (graph-direct) view
+    /// that includes pass-throughs, use
+    /// [`raw_predecessors`][Self::raw_predecessors].
     ///
     /// Returns an error if the given `component_id` does not exist.
-    pub fn predecessors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
-        self.node_indices
-            .get(&component_id)
-            .map(|&index| RawNeighbors {
-                graph: &self.graph,
-                iter: self
-                    .graph
-                    .neighbors_directed(index, petgraph::Direction::Incoming),
-            })
-            .ok_or_else(|| {
-                Error::component_not_found(format!("Component with id {component_id} not found."))
-            })
+    pub fn predecessors(&self, component_id: u64) -> Result<Neighbors<'_, N>, Error> {
+        self.collect_effective_neighbors(component_id, petgraph::Direction::Incoming)
     }
 
-    /// Returns an iterator over the *successors* of the component with the
-    /// given `component_id`.
+    /// Returns an iterator over the *successors* of the component with
+    /// the given `component_id`, walking transparently past pass-through
+    /// categories.
+    ///
+    /// Pass-through nodes are skipped: their non-pass-through descendants
+    /// take their place in the iterator. For the raw (graph-direct) view
+    /// that includes pass-throughs, use
+    /// [`raw_successors`][Self::raw_successors].
     ///
     /// Returns an error if the given `component_id` does not exist.
-    pub fn successors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
-        self.node_indices
-            .get(&component_id)
-            .map(|&index| RawNeighbors {
-                graph: &self.graph,
-                iter: self
-                    .graph
-                    .neighbors_directed(index, petgraph::Direction::Outgoing),
-            })
-            .ok_or_else(|| {
-                Error::component_not_found(format!("Component with id {component_id} not found."))
-            })
+    pub fn successors(&self, component_id: u64) -> Result<Neighbors<'_, N>, Error> {
+        self.collect_effective_neighbors(component_id, petgraph::Direction::Outgoing)
+    }
+
+    /// BFS through pass-through nodes in the given direction, collecting
+    /// the first non-pass-through node along each branch.
+    fn collect_effective_neighbors(
+        &self,
+        component_id: u64,
+        direction: petgraph::Direction,
+    ) -> Result<Neighbors<'_, N>, Error> {
+        let start = *self.node_indices.get(&component_id).ok_or_else(|| {
+            Error::component_not_found(format!("Component with id {component_id} not found."))
+        })?;
+
+        let mut queue: VecDeque<NodeIndex> =
+            self.graph.neighbors_directed(start, direction).collect();
+        let mut visited: HashSet<NodeIndex> = HashSet::new();
+        let mut result: Vec<&N> = Vec::new();
+
+        while let Some(idx) = queue.pop_front() {
+            if !visited.insert(idx) {
+                continue;
+            }
+            let node = &self.graph[idx];
+            if node.category().is_passthrough() {
+                queue.extend(self.graph.neighbors_directed(idx, direction));
+            } else {
+                result.push(node);
+            }
+        }
+
+        Ok(Neighbors {
+            iter: result.into_iter(),
+        })
     }
 
     /// Returns an iterator over the *siblings* of the component with the
@@ -174,7 +200,9 @@ where
 
         while let Some(index) = stack.pop() {
             let node = &self.graph[index];
-            if pred(node) {
+            // Pass-through nodes are transparent: skip the predicate
+            // check but follow through their neighbors.
+            if !node.category().is_passthrough() && pred(node) {
                 found.insert(node.component_id());
                 if !follow_after_match {
                     continue;
@@ -409,6 +437,103 @@ mod tests {
             ]
         );
 
+        Ok(())
+    }
+
+    /// `raw_predecessors` / `raw_successors` expose the graph-direct
+    /// view (including pass-through nodes), while `predecessors` /
+    /// `successors` walk past them.
+    ///
+    /// Topology: `Grid → PT → Meter → BatteryInverter → Battery`.
+    #[test]
+    fn test_raw_neighbors_includes_passthroughs() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let pt = builder.power_transformer();
+        let meter = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, pt);
+        builder.connect(pt, meter);
+        builder.connect(meter, inverter);
+        builder.connect(inverter, battery);
+
+        let graph = builder.build(None)?;
+
+        // Raw view sees the PT directly.
+        let raw_preds: Vec<u64> = graph
+            .raw_predecessors(meter.component_id())?
+            .map(|n| n.component_id())
+            .collect();
+        assert_eq!(raw_preds, vec![pt.component_id()]);
+
+        let raw_succs: Vec<u64> = graph
+            .raw_successors(grid.component_id())?
+            .map(|n| n.component_id())
+            .collect();
+        assert_eq!(raw_succs, vec![pt.component_id()]);
+
+        // Effective view walks past the PT.
+        let preds: Vec<u64> = graph
+            .predecessors(meter.component_id())?
+            .map(|n| n.component_id())
+            .collect();
+        assert_eq!(preds, vec![grid.component_id()]);
+
+        let succs: Vec<u64> = graph
+            .successors(grid.component_id())?
+            .map(|n| n.component_id())
+            .collect();
+        assert_eq!(succs, vec![meter.component_id()]);
+
+        // Unknown component_id behaves the same as the effective methods.
+        assert!(graph.raw_predecessors(999).is_err());
+        assert!(graph.raw_successors(999).is_err());
+
+        // Make sure the unused `battery` and `inverter` handles aren't
+        // optimised away in unrelated test setup.
+        let _ = (battery, inverter);
+        Ok(())
+    }
+
+    /// `find_all` skips pass-through nodes when checking the predicate
+    /// — even if the predicate would match. This keeps PTs out of
+    /// callers' result sets without forcing them to filter.
+    ///
+    /// Topology: `Grid → PT → Meter`.
+    #[test]
+    fn test_find_all_skips_passthroughs() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let pt = builder.power_transformer();
+        let meter = builder.meter();
+
+        builder.connect(grid, pt);
+        builder.connect(pt, meter);
+
+        let graph = builder.build(None)?;
+
+        // Predicate matches everything; PT is excluded from the result.
+        let found = graph.find_all(
+            grid.component_id(),
+            |_| true,
+            petgraph::Direction::Outgoing,
+            true,
+        )?;
+        assert_eq!(
+            found,
+            BTreeSet::from([grid.component_id(), meter.component_id()])
+        );
+
+        // Predicate that explicitly tries to match PTs still returns nothing.
+        let found = graph.find_all(
+            grid.component_id(),
+            |n| n.category() == ComponentCategory::PowerTransformer,
+            petgraph::Direction::Outgoing,
+            true,
+        )?;
+        assert!(found.is_empty());
         Ok(())
     }
 

--- a/src/graph/retrieval.rs
+++ b/src/graph/retrieval.rs
@@ -48,17 +48,7 @@ where
     ///
     /// Returns an error if the given `component_id` does not exist.
     pub fn raw_predecessors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
-        self.node_indices
-            .get(&component_id)
-            .map(|&index| RawNeighbors {
-                graph: &self.graph,
-                iter: self
-                    .graph
-                    .neighbors_directed(index, petgraph::Direction::Incoming),
-            })
-            .ok_or_else(|| {
-                Error::component_not_found(format!("Component with id {component_id} not found."))
-            })
+        self.raw_neighbors(component_id, petgraph::Direction::Incoming)
     }
 
     /// Returns an iterator over the *raw* (graph-direct) successors of
@@ -71,13 +61,21 @@ where
     ///
     /// Returns an error if the given `component_id` does not exist.
     pub fn raw_successors(&self, component_id: u64) -> Result<RawNeighbors<'_, N>, Error> {
+        self.raw_neighbors(component_id, petgraph::Direction::Outgoing)
+    }
+
+    /// Shared implementation for [`raw_predecessors`][Self::raw_predecessors]
+    /// and [`raw_successors`][Self::raw_successors].
+    fn raw_neighbors(
+        &self,
+        component_id: u64,
+        direction: petgraph::Direction,
+    ) -> Result<RawNeighbors<'_, N>, Error> {
         self.node_indices
             .get(&component_id)
             .map(|&index| RawNeighbors {
                 graph: &self.graph,
-                iter: self
-                    .graph
-                    .neighbors_directed(index, petgraph::Direction::Outgoing),
+                iter: self.graph.neighbors_directed(index, direction),
             })
             .ok_or_else(|| {
                 Error::component_not_found(format!("Component with id {component_id} not found."))

--- a/src/graph/test_utils.rs
+++ b/src/graph/test_utils.rs
@@ -160,6 +160,11 @@ impl ComponentGraphBuilder {
         self.add_component(ComponentCategory::SteamBoiler)
     }
 
+    /// Adds a power transformer (pass-through category) to the graph.
+    pub(super) fn power_transformer(&mut self) -> ComponentHandle {
+        self.add_component(ComponentCategory::PowerTransformer)
+    }
+
     /// Connects two components in the graph.
     pub(super) fn connect(&mut self, from: ComponentHandle, to: ComponentHandle) -> &mut Self {
         self.connections

--- a/src/graph/validation/validate_graph.rs
+++ b/src/graph/validation/validate_graph.rs
@@ -66,13 +66,13 @@ where
     ) -> Result<(), Error> {
         predecessors.push(node.component_id());
         for successor in self.cg.raw_successors(node.component_id())? {
-            if let Some(first_occurance) = predecessors
+            if let Some(first_occurrence) = predecessors
                 .iter()
                 .position(|id| *id == successor.component_id())
             {
                 return Err(Error::invalid_graph(format!(
                     "Cycle detected: {} -> {}",
-                    predecessors[first_occurance..]
+                    predecessors[first_occurrence..]
                         .iter()
                         .map(|x| x.to_string())
                         .collect::<Vec<_>>()

--- a/src/graph/validation/validate_graph.rs
+++ b/src/graph/validation/validate_graph.rs
@@ -15,10 +15,15 @@ where
     N: Node,
     E: Edge,
 {
-    /// Validates that all components are connected into a single graph.
+    /// Validates that all non-pass-through components are connected
+    /// into a single graph.
     ///
-    /// It does so by ensuring that all the components are reachable by
-    /// traversing the graph from the root node.
+    /// It does so by ensuring that all the components are reachable
+    /// by traversing the graph from the root node. Pass-through
+    /// components are exempt: they're transparent to the effective
+    /// successors view, so the walk never visits them, and we don't
+    /// require them to be reachable -- even when
+    /// `allow_unconnected_components` is `false`.
     pub(super) fn validate_connected_graph(&self, root: &N) -> Result<(), Error> {
         let root_id = root.component_id();
         let mut visited = BTreeSet::new();
@@ -34,6 +39,7 @@ where
         let unvisited = self
             .cg
             .components()
+            .filter(|n| !n.category().is_passthrough())
             .map(|n| n.component_id())
             .filter(|id| !visited.contains(id))
             .collect::<Vec<_>>();
@@ -50,14 +56,16 @@ where
     /// Validates that there are no cycles in the graph.
     ///
     /// If a cycle is detected, an error is returned, that lists the nodes in
-    /// the cycle.
+    /// the cycle. Walks via `raw_successors` so cycles composed entirely of
+    /// pass-through nodes (which are invisible to the effective view) are
+    /// still detected.
     pub(super) fn validate_acyclicity(
         &self,
         node: &N,
         mut predecessors: Vec<u64>,
     ) -> Result<(), Error> {
         predecessors.push(node.component_id());
-        for successor in self.cg.successors(node.component_id())? {
+        for successor in self.cg.raw_successors(node.component_id())? {
             if let Some(first_occurance) = predecessors
                 .iter()
                 .position(|id| *id == successor.component_id())

--- a/src/graph/validation/validate_neighbors.rs
+++ b/src/graph/validation/validate_neighbors.rs
@@ -239,7 +239,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::Inverter(InverterType::Battery)),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -254,7 +254,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone()).is_err_and(|e| {
                 e == Error::invalid_graph(
-                    "BatteryInverter:3 can only have successors that are Batteries. Found Electrolyzer:4.",
+                    "BatteryInverter:3 can only have successors that are Batteries. Found WindTurbine:4.",
                 )
             }),
             "{}",
@@ -287,7 +287,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::Inverter(InverterType::Pv)),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -299,7 +299,7 @@ r#"InvalidGraph: Multiple validation failures:
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
                     e == Error::invalid_graph(
-                        "PvInverter:3 can't have any successors. Found Electrolyzer:4.",
+                        "PvInverter:3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
         );
@@ -329,7 +329,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::Inverter(InverterType::Hybrid)),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -341,7 +341,7 @@ r#"InvalidGraph: Multiple validation failures:
                 .is_err_and(|e| {
                     e == Error::invalid_graph(concat!(
                         "HybridInverter:3 can only have successors that are Batteries. ",
-                        "Found Electrolyzer:4."
+                        "Found WindTurbine:4."
                     ))
                 }),
         );
@@ -436,7 +436,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::EvCharger(EvChargerType::Dc)),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -447,7 +447,7 @@ r#"InvalidGraph: Multiple validation failures:
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
                     e == Error::invalid_graph(
-                        "EVCharger(DC):3 can't have any successors. Found Electrolyzer:4.",
+                        "EVCharger(DC):3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
         );
@@ -465,7 +465,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::Chp),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -476,7 +476,7 @@ r#"InvalidGraph: Multiple validation failures:
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
                     e == Error::invalid_graph(
-                        "CHP:3 can't have any successors. Found Electrolyzer:4.",
+                        "CHP:3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
         );
@@ -494,7 +494,7 @@ r#"InvalidGraph: Multiple validation failures:
             TestComponent::new(1, ComponentCategory::GridConnectionPoint),
             TestComponent::new(2, ComponentCategory::Meter),
             TestComponent::new(3, ComponentCategory::SteamBoiler),
-            TestComponent::new(4, ComponentCategory::Electrolyzer),
+            TestComponent::new(4, ComponentCategory::WindTurbine),
         ];
         let mut connections = vec![
             TestConnection::new(1, 2),
@@ -505,7 +505,7 @@ r#"InvalidGraph: Multiple validation failures:
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
                     e == Error::invalid_graph(
-                        "SteamBoiler:3 can't have any successors. Found Electrolyzer:4.",
+                        "SteamBoiler:3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
         );

--- a/src/graph_traits.rs
+++ b/src/graph_traits.rs
@@ -109,7 +109,7 @@ impl frequenz_microgrid_component_graph::Node for common::v1::microgrid::compone
             pb::ComponentCategory::CryptoMiner => gr::ComponentCategory::CryptoMiner,
             pb::ComponentCategory::Electrolyzer => gr::ComponentCategory::Electrolyzer,
             pb::ComponentCategory::Chp => gr::ComponentCategory::Chp,
-            pb::ComponentCategory::Relay => gr::ComponentCategory::Relay,
+            pb::ComponentCategory::Relay => gr::ComponentCategory::Breaker,
             pb::ComponentCategory::Precharger => gr::ComponentCategory::Precharger,
             pb::ComponentCategory::VoltageTransformer => gr::ComponentCategory::PowerTransformer,
             pb::ComponentCategory::Hvac => gr::ComponentCategory::Hvac,

--- a/src/graph_traits.rs
+++ b/src/graph_traits.rs
@@ -31,7 +31,7 @@ impl frequenz_microgrid_component_graph::Node for common::v1::microgrid::compone
 
         match category {
             pb::ComponentCategory::Unspecified => gr::ComponentCategory::Unspecified,
-            pb::ComponentCategory::Grid => gr::ComponentCategory::Grid,
+            pb::ComponentCategory::Grid => gr::ComponentCategory::GridConnectionPoint,
             pb::ComponentCategory::Meter => gr::ComponentCategory::Meter,
             pb::ComponentCategory::Inverter => {
                 gr::ComponentCategory::Inverter(match self.category_type {
@@ -43,7 +43,7 @@ impl frequenz_microgrid_component_graph::Node for common::v1::microgrid::compone
                                 error!("Error converting inverter type: {}", e);
                                 pb::InverterType::Unspecified
                             }) {
-                                pb::InverterType::Solar => gr::InverterType::Solar,
+                                pb::InverterType::Solar => gr::InverterType::Pv,
                                 pb::InverterType::Battery => gr::InverterType::Battery,
                                 pb::InverterType::Hybrid => gr::InverterType::Hybrid,
                                 pb::InverterType::Unspecified => gr::InverterType::Unspecified,
@@ -111,8 +111,7 @@ impl frequenz_microgrid_component_graph::Node for common::v1::microgrid::compone
             pb::ComponentCategory::Chp => gr::ComponentCategory::Chp,
             pb::ComponentCategory::Relay => gr::ComponentCategory::Relay,
             pb::ComponentCategory::Precharger => gr::ComponentCategory::Precharger,
-            pb::ComponentCategory::Fuse => gr::ComponentCategory::Fuse,
-            pb::ComponentCategory::VoltageTransformer => gr::ComponentCategory::VoltageTransformer,
+            pb::ComponentCategory::VoltageTransformer => gr::ComponentCategory::PowerTransformer,
             pb::ComponentCategory::Hvac => gr::ComponentCategory::Hvac,
             pb::ComponentCategory::SteamBoiler => gr::ComponentCategory::SteamBoiler,
         }


### PR DESCRIPTION
This PR updates the component-graph traversal and validation/modeling layers to treat certain “unhandled” component categories as *pass-through* (transparent) nodes, so validation rules and formula generation operate on the effective topology rather than the raw graph.

**Changes:**
- Introduce *effective* neighbor traversal that skips pass-through categories, while adding `raw_predecessors` / `raw_successors` for graph-direct traversal.
- Update connectedness validation to ignore pass-through nodes, and add pass-through-focused formula/validation tests.
- Add pass-through classification via `ComponentCategory::is_passthrough()` and emit operator warnings for pass-through components during graph construction.
