### PR TITLE
Make graph validation errors structured and inspectable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@
 
 - Use the builder pattern from now on to construct `ComponentGraphConfig`: fields are `pub(crate)` and construction goes through the new `ComponentGraphConfig::builder()`. With this, adding a new config option will no longer be a breaking change. The six per-category `prefer_X_in_Y_formula` flags are replaced by a global `prefer_meters_in_component_formulas` with per-formula overrides via `FormulaOverrides`.
 
+- Graph validation failures are now reported as `ErrorKind::ValidationErrors(Vec<ValidationError>)` rather than flattened into a single `InvalidGraph` error. Their `Display` changed accordingly: each failure is listed on its own line under a `Graph validation failed:` header, without the old per-line `InvalidGraph:` prefixes.
+
 ## New Features
 
-A new component category, steam boiler, was added.
+- A new component category, steam boiler, was added.
+
+- `ErrorKind` and `ValidationError` are now public. `Error::kind()` exposes the kind, and each `ValidationError` reports its `message()` and the `component_ids()` it involves, so individual validation failures (including detected cycles) can be inspected programmatically instead of parsed from a string.

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,12 @@
 //! graph.
 
 /// The kind of an [`Error`].
+///
+/// Marked `#[non_exhaustive]`: matching on this enum from outside the crate
+/// must include a wildcard arm, so future kinds can be added without a
+/// breaking change.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// No component was found for a given component ID.
     ComponentNotFound,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
 // License: MIT
 // Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-//! This module defines the `Error` struct and the `ErrorKind` enum, which are
-//! used to represent errors that can occur in the library.
+//! This module defines the [`Error`] struct and the [`ErrorKind`] enum, which
+//! represent errors that can occur in the library, along with
+//! [`ValidationError`] for the individual failures collected while validating a
+//! graph.
 
 /// The kind of an [`Error`].
 #[derive(Debug, Clone, PartialEq)]
@@ -22,6 +24,10 @@ pub enum ErrorKind {
     /// The graph is structurally invalid, e.g. it has no grid component,
     /// several grid components, or a duplicate component ID.
     InvalidGraph,
+
+    /// One or more checks failed while validating an otherwise well-formed
+    /// graph. Holds every [`ValidationError`] that was collected.
+    ValidationErrors(Vec<ValidationError>),
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -32,6 +38,7 @@ impl std::fmt::Display for ErrorKind {
             Self::InvalidComponent => "InvalidComponent",
             Self::InvalidConnection => "InvalidConnection",
             Self::InvalidGraph => "InvalidGraph",
+            Self::ValidationErrors(_) => "ValidationErrors",
         };
         f.write_str(name)
     }
@@ -49,6 +56,21 @@ impl Error {
     /// Returns the [`ErrorKind`] of this error.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
+    }
+
+    /// If this is an [`ErrorKind::ValidationErrors`], returns the collected
+    /// failures; otherwise returns the error unchanged. Any other kind arising
+    /// during validation signals an internal inconsistency rather than a
+    /// topology failure (e.g. a graph lookup returning `ComponentNotFound`), so
+    /// it is propagated to abort validation rather than collected.
+    pub(crate) fn into_validation_errors(self) -> Result<Vec<ValidationError>, Error> {
+        match self.kind {
+            ErrorKind::ValidationErrors(errors) => Ok(errors),
+            kind => Err(Error {
+                kind,
+                desc: self.desc,
+            }),
+        }
     }
 }
 
@@ -98,12 +120,119 @@ impl Error {
             desc: desc.into(),
         }
     }
+
+    /// Creates a new [`Error`] with the `ValidationErrors` kind from the
+    /// collected validation failures.
+    pub(crate) fn validation_errors(errors: Vec<ValidationError>) -> Self {
+        // The failures carry their own descriptions, so `desc` is unused for
+        // this kind; `Display` formats the collected errors directly.
+        Self {
+            kind: ErrorKind::ValidationErrors(errors),
+            desc: String::new(),
+        }
+    }
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.kind, self.desc)
+        match &self.kind {
+            ErrorKind::ValidationErrors(errors) => {
+                write!(f, "Graph validation failed:")?;
+                for error in errors {
+                    write!(f, "\n    {error}")?;
+                }
+                Ok(())
+            }
+            kind => write!(f, "{kind}: {}", self.desc),
+        }
     }
 }
 
 impl std::error::Error for Error {}
+
+/// A single failure found while validating a
+/// [`ComponentGraph`][crate::ComponentGraph]'s topology.
+///
+/// Validation collects every failure rather than stopping at the first one, so
+/// a single graph can yield many of these (see [`ErrorKind::ValidationErrors`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError {
+    message: String,
+}
+
+impl ValidationError {
+    /// Creates a new validation error from a message.
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// A human-readable description of the failure.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+impl From<ValidationError> for Error {
+    fn from(error: ValidationError) -> Self {
+        Error::validation_errors(vec![error])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_error_displays_its_message() {
+        let error = ValidationError::new("boom");
+        assert_eq!(error.message(), "boom");
+        assert_eq!(error.to_string(), "boom");
+    }
+
+    #[test]
+    fn leaf_error_display_is_unchanged() {
+        assert_eq!(
+            Error::invalid_graph("No grid component found.").to_string(),
+            "InvalidGraph: No grid component found."
+        );
+    }
+
+    #[test]
+    fn validation_errors_display_lists_each_failure() {
+        let error = Error::validation_errors(vec![
+            ValidationError::new("first problem"),
+            ValidationError::new("second problem"),
+        ]);
+        assert_eq!(
+            error.to_string(),
+            "Graph validation failed:\n    first problem\n    second problem"
+        );
+    }
+
+    #[test]
+    fn into_validation_errors_unwraps_the_collected_failures() {
+        let error: Error = ValidationError::new("boom").into();
+        assert_eq!(
+            error.into_validation_errors(),
+            Ok(vec![ValidationError::new("boom")])
+        );
+    }
+
+    #[test]
+    fn into_validation_errors_passes_other_kinds_through() {
+        assert_eq!(
+            Error::internal("bug").into_validation_errors(),
+            Err(Error::internal("bug"))
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,22 +155,33 @@ impl std::error::Error for Error {}
 ///
 /// Validation collects every failure rather than stopping at the first one, so
 /// a single graph can yield many of these (see [`ErrorKind::ValidationErrors`]).
+/// Besides a human-readable [`message`][Self::message], each failure exposes the
+/// [`component_ids`][Self::component_ids] it involves, so callers can act on the
+/// affected components without parsing the message text.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidationError {
     message: String,
+    component_ids: Vec<u64>,
 }
 
 impl ValidationError {
-    /// Creates a new validation error from a message.
-    pub(crate) fn new(message: impl Into<String>) -> Self {
+    /// Creates a new validation error from a message and the IDs of the
+    /// components it involves.
+    pub(crate) fn new(message: impl Into<String>, component_ids: impl Into<Vec<u64>>) -> Self {
         Self {
             message: message.into(),
+            component_ids: component_ids.into(),
         }
     }
 
     /// A human-readable description of the failure.
     pub fn message(&self) -> &str {
         &self.message
+    }
+
+    /// The IDs of the components involved in the failure.
+    pub fn component_ids(&self) -> &[u64] {
+        &self.component_ids
     }
 }
 
@@ -193,9 +204,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validation_error_displays_its_message() {
-        let error = ValidationError::new("boom");
+    fn validation_error_exposes_its_message_and_components() {
+        let error = ValidationError::new("boom", [3u64, 4]);
         assert_eq!(error.message(), "boom");
+        assert_eq!(error.component_ids(), &[3, 4]);
+        // `Display` is just the message.
         assert_eq!(error.to_string(), "boom");
     }
 
@@ -210,8 +223,8 @@ mod tests {
     #[test]
     fn validation_errors_display_lists_each_failure() {
         let error = Error::validation_errors(vec![
-            ValidationError::new("first problem"),
-            ValidationError::new("second problem"),
+            ValidationError::new("first problem", [1u64]),
+            ValidationError::new("second problem", [2u64, 3]),
         ]);
         assert_eq!(
             error.to_string(),
@@ -221,10 +234,10 @@ mod tests {
 
     #[test]
     fn into_validation_errors_unwraps_the_collected_failures() {
-        let error: Error = ValidationError::new("boom").into();
+        let error: Error = ValidationError::new("boom", [1u64]).into();
         assert_eq!(
             error.into_validation_errors(),
-            Ok(vec![ValidationError::new("boom")])
+            Ok(vec![ValidationError::new("boom", [1u64])])
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,56 +4,28 @@
 //! This module defines the `Error` struct and the `ErrorKind` enum, which are
 //! used to represent errors that can occur in the library.
 
-/// A macro for defining the `ErrorKind` enum, the `Display` implementation for
-/// it, and the constructors for the `Error` struct.
-macro_rules! ErrorKind {
-    ($(
-        ($kind:ident, $ctor:ident)
-    ),*) => {
-        /// The kind of error that occurred.
-        #[derive(Debug, Clone, PartialEq)]
-        pub(crate) enum ErrorKind {
-            $(
-                $kind,
-            )*
-        }
-
-        impl std::fmt::Display for ErrorKind {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self {
-                    $(
-                        Self::$kind => write!(f, "{}", stringify!($kind)),
-                    )*
-                }
-            }
-        }
-
-        /// Constructors for [`Error`].
-        impl Error {
-            $(
-                #[doc = concat!(
-                    "Creates a new [`Error`] with the `",
-                    stringify!($kind),
-                    "` kind and the given description."
-                )]
-                pub(crate) fn $ctor(desc: impl Into<String>) -> crate::Error {
-                    Self {
-                        kind: ErrorKind::$kind,
-                        desc: desc.into(),
-                    }
-                }
-            )*
-        }
-    };
+/// The kind of error that occurred.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ErrorKind {
+    ComponentNotFound,
+    Internal,
+    InvalidComponent,
+    InvalidConnection,
+    InvalidGraph,
 }
 
-ErrorKind!(
-    (ComponentNotFound, component_not_found),
-    (Internal, internal),
-    (InvalidComponent, invalid_component),
-    (InvalidConnection, invalid_connection),
-    (InvalidGraph, invalid_graph)
-);
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::ComponentNotFound => "ComponentNotFound",
+            Self::Internal => "Internal",
+            Self::InvalidComponent => "InvalidComponent",
+            Self::InvalidConnection => "InvalidConnection",
+            Self::InvalidGraph => "InvalidGraph",
+        };
+        f.write_str(name)
+    }
+}
 
 /// An error that can occur during the creation or traversal of a
 /// [ComponentGraph][crate::ComponentGraph].
@@ -61,6 +33,54 @@ ErrorKind!(
 pub struct Error {
     kind: ErrorKind,
     desc: String,
+}
+
+/// Constructors for [`Error`].
+impl Error {
+    /// Creates a new [`Error`] with the `ComponentNotFound` kind and the given
+    /// description.
+    pub(crate) fn component_not_found(desc: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::ComponentNotFound,
+            desc: desc.into(),
+        }
+    }
+
+    /// Creates a new [`Error`] with the `Internal` kind and the given
+    /// description.
+    pub(crate) fn internal(desc: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Internal,
+            desc: desc.into(),
+        }
+    }
+
+    /// Creates a new [`Error`] with the `InvalidComponent` kind and the given
+    /// description.
+    pub(crate) fn invalid_component(desc: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::InvalidComponent,
+            desc: desc.into(),
+        }
+    }
+
+    /// Creates a new [`Error`] with the `InvalidConnection` kind and the given
+    /// description.
+    pub(crate) fn invalid_connection(desc: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::InvalidConnection,
+            desc: desc.into(),
+        }
+    }
+
+    /// Creates a new [`Error`] with the `InvalidGraph` kind and the given
+    /// description.
+    pub(crate) fn invalid_graph(desc: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::InvalidGraph,
+            desc: desc.into(),
+        }
+    }
 }
 
 impl std::fmt::Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,23 @@
 //! This module defines the `Error` struct and the `ErrorKind` enum, which are
 //! used to represent errors that can occur in the library.
 
-/// The kind of error that occurred.
+/// The kind of an [`Error`].
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum ErrorKind {
+pub enum ErrorKind {
+    /// No component was found for a given component ID.
     ComponentNotFound,
+
+    /// An internal invariant of the library was violated. This indicates a bug.
     Internal,
+
+    /// A component is invalid, e.g. it has an unspecified category.
     InvalidComponent,
+
+    /// A connection between two components is invalid.
     InvalidConnection,
+
+    /// The graph is structurally invalid, e.g. it has no grid component,
+    /// several grid components, or a duplicate component ID.
     InvalidGraph,
 }
 
@@ -33,6 +43,13 @@ impl std::fmt::Display for ErrorKind {
 pub struct Error {
     kind: ErrorKind,
     desc: String,
+}
+
+impl Error {
+    /// Returns the [`ErrorKind`] of this error.
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
 }
 
 /// Constructors for [`Error`].

--- a/src/graph/test_utils.rs
+++ b/src/graph/test_utils.rs
@@ -11,8 +11,14 @@
 
 use crate::{
     BatteryType, ComponentCategory, ComponentGraph, ComponentGraphConfig, Edge, Error,
-    EvChargerType, InverterType, Node,
+    EvChargerType, InverterType, Node, ValidationError,
 };
+
+/// Builds the [`Error`] that validation returns when it collects a single
+/// failure with the given message.
+pub(super) fn validation_error(message: &str) -> Error {
+    Error::validation_errors(vec![ValidationError::new(message)])
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct TestComponent(u64, ComponentCategory);

--- a/src/graph/test_utils.rs
+++ b/src/graph/test_utils.rs
@@ -15,9 +15,9 @@ use crate::{
 };
 
 /// Builds the [`Error`] that validation returns when it collects a single
-/// failure with the given message.
-pub(super) fn validation_error(message: &str) -> Error {
-    Error::validation_errors(vec![ValidationError::new(message)])
+/// failure with the given message and affected component IDs.
+pub(super) fn validation_error(message: &str, component_ids: &[u64]) -> Error {
+    Error::validation_errors(vec![ValidationError::new(message, component_ids.to_vec())])
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/graph/validation.rs
+++ b/src/graph/validation.rs
@@ -33,16 +33,17 @@ where
 
         let validator = ComponentGraphValidator { cg: self, root };
 
-        // Fail immediately if there are cycles in the graph, as this may cause
-        // subsequent validations to get stuck in an infinite loop.
+        // Reject cycles before anything else: the remaining checks walk the
+        // graph and would loop forever on a cyclic one. A detected cycle
+        // short-circuits here, as does any internal failure during traversal.
         validator.validate_acyclicity(root, vec![])?;
 
         let mut errors = vec![];
-        let mut validation_failed = false;
+        let mut fatal = false;
 
-        if let Err(err) = validator.validate_connected_graph(root) {
-            errors.push(err);
-            validation_failed |= !self.config.allow_unconnected_components;
+        if let Err(error) = validator.validate_connected_graph(root) {
+            errors.extend(error.into_validation_errors()?);
+            fatal |= !self.config.allow_unconnected_components;
         }
 
         for result in [
@@ -54,36 +55,24 @@ where
             validator.validate_chps(),
             validator.validate_steam_boilers(),
         ] {
-            if let Err(e) = result {
-                errors.push(e);
-                validation_failed |= !self.config.allow_component_validation_failures;
+            if let Err(error) = result {
+                errors.extend(error.into_validation_errors()?);
+                fatal |= !self.config.allow_component_validation_failures;
             }
         }
-        match errors.len() {
-            0 => {}
-            1 => {
-                if validation_failed {
-                    return Err(errors[0].clone());
-                } else {
-                    tracing::warn!("{}", errors[0]);
-                }
-            }
-            _ => {
-                let err = Error::invalid_graph(format!(
-                    "Multiple validation failures:\n    {}",
-                    errors
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join("\n    ")
-                ));
-                if validation_failed {
-                    return Err(err);
-                } else {
-                    tracing::warn!("{}", err);
-                }
-            }
+
+        if errors.is_empty() {
+            return Ok(());
         }
-        Ok(())
+
+        let error = Error::validation_errors(errors);
+        if fatal {
+            Err(error)
+        } else {
+            // Every collected failure is tolerated by the configuration, so
+            // report them as a warning instead of failing construction.
+            tracing::warn!("{error}");
+            Ok(())
+        }
     }
 }

--- a/src/graph/validation.rs
+++ b/src/graph/validation.rs
@@ -42,7 +42,7 @@ where
 
         if let Err(err) = validator.validate_connected_graph(root) {
             errors.push(err);
-            validation_failed = !self.config.allow_unconnected_components;
+            validation_failed |= !self.config.allow_unconnected_components;
         }
 
         for result in [
@@ -56,7 +56,7 @@ where
         ] {
             if let Err(e) = result {
                 errors.push(e);
-                validation_failed = !self.config.allow_component_validation_failures;
+                validation_failed |= !self.config.allow_component_validation_failures;
             }
         }
         match errors.len() {

--- a/src/graph/validation/invariant_checks.rs
+++ b/src/graph/validation/invariant_checks.rs
@@ -3,7 +3,7 @@
 
 //! Helper methods for checking invariants of a [`ComponentGraph`].
 
-use crate::{Edge, Error, Node};
+use crate::{Edge, Error, Node, ValidationError};
 
 use super::ComponentGraphValidator;
 
@@ -15,13 +15,14 @@ where
     /// Checks that the given node is a leaf node.
     pub(super) fn ensure_leaf(&self, node: &N) -> Result<(), Error> {
         if let Some(successor) = self.cg.successors(node.component_id())?.next() {
-            return Err(Error::invalid_graph(format!(
+            return Err(ValidationError::new(format!(
                 "{}:{} can't have any successors. Found {}:{}.",
                 node.category(),
                 node.component_id(),
                 successor.category(),
                 successor.component_id()
-            )));
+            ))
+            .into());
         }
         Ok(())
     }
@@ -29,11 +30,12 @@ where
     /// Checks that the given node is *not* a leaf node.
     pub(super) fn ensure_not_leaf(&self, node: &N) -> Result<(), Error> {
         if self.cg.successors(node.component_id())?.next().is_none() {
-            return Err(Error::invalid_graph(format!(
+            return Err(ValidationError::new(format!(
                 "{}:{} must have at least one successor.",
                 node.category(),
                 node.component_id()
-            )));
+            ))
+            .into());
         }
         Ok(())
     }
@@ -41,13 +43,14 @@ where
     /// Checks that the given node is a root node.
     pub(super) fn ensure_root(&self, node: &N) -> Result<(), Error> {
         if let Some(predecessor) = self.cg.predecessors(node.component_id())?.next() {
-            return Err(Error::invalid_graph(format!(
+            return Err(ValidationError::new(format!(
                 "{}:{} can't have any predecessors. Found {}:{}.",
                 node.category(),
                 node.component_id(),
                 predecessor.category(),
                 predecessor.component_id()
-            )));
+            ))
+            .into());
         }
         Ok(())
     }
@@ -61,14 +64,15 @@ where
     ) -> Result<(), Error> {
         for predecessor in self.cg.predecessors(node.component_id())? {
             if !predicate(predecessor) {
-                return Err(Error::invalid_graph(format!(
+                return Err(ValidationError::new(format!(
                     "{}:{} can only have predecessors that are {}. Found {}:{}.",
                     node.category(),
                     node.component_id(),
                     failure_message,
                     predecessor.category(),
                     predecessor.component_id()
-                )));
+                ))
+                .into());
             }
         }
         Ok(())
@@ -83,14 +87,15 @@ where
     ) -> Result<(), Error> {
         for successor in self.cg.successors(node.component_id())? {
             if !predicate(successor) {
-                return Err(Error::invalid_graph(format!(
+                return Err(ValidationError::new(format!(
                     "{}:{} can only have successors that are {}. Found {}:{}.",
                     node.category(),
                     node.component_id(),
                     failure_message,
                     successor.category(),
                     successor.component_id()
-                )));
+                ))
+                .into());
             }
         }
         Ok(())
@@ -103,13 +108,14 @@ where
     pub(super) fn ensure_exclusive_successors(&self, node: &N) -> Result<(), Error> {
         for successor in self.cg.successors(node.component_id())? {
             if self.cg.predecessors(successor.component_id())?.count() > 1 {
-                return Err(Error::invalid_graph(format!(
+                return Err(ValidationError::new(format!(
                     "{}:{} can't have successors with multiple predecessors. Found {}:{}.",
                     node.category(),
                     node.component_id(),
                     successor.category(),
                     successor.component_id()
-                )));
+                ))
+                .into());
             }
         }
         Ok(())

--- a/src/graph/validation/invariant_checks.rs
+++ b/src/graph/validation/invariant_checks.rs
@@ -15,13 +15,16 @@ where
     /// Checks that the given node is a leaf node.
     pub(super) fn ensure_leaf(&self, node: &N) -> Result<(), Error> {
         if let Some(successor) = self.cg.successors(node.component_id())?.next() {
-            return Err(ValidationError::new(format!(
-                "{}:{} can't have any successors. Found {}:{}.",
-                node.category(),
-                node.component_id(),
-                successor.category(),
-                successor.component_id()
-            ))
+            return Err(ValidationError::new(
+                format!(
+                    "{}:{} can't have any successors. Found {}:{}.",
+                    node.category(),
+                    node.component_id(),
+                    successor.category(),
+                    successor.component_id()
+                ),
+                [node.component_id(), successor.component_id()],
+            )
             .into());
         }
         Ok(())
@@ -30,11 +33,14 @@ where
     /// Checks that the given node is *not* a leaf node.
     pub(super) fn ensure_not_leaf(&self, node: &N) -> Result<(), Error> {
         if self.cg.successors(node.component_id())?.next().is_none() {
-            return Err(ValidationError::new(format!(
-                "{}:{} must have at least one successor.",
-                node.category(),
-                node.component_id()
-            ))
+            return Err(ValidationError::new(
+                format!(
+                    "{}:{} must have at least one successor.",
+                    node.category(),
+                    node.component_id()
+                ),
+                [node.component_id()],
+            )
             .into());
         }
         Ok(())
@@ -43,13 +49,16 @@ where
     /// Checks that the given node is a root node.
     pub(super) fn ensure_root(&self, node: &N) -> Result<(), Error> {
         if let Some(predecessor) = self.cg.predecessors(node.component_id())?.next() {
-            return Err(ValidationError::new(format!(
-                "{}:{} can't have any predecessors. Found {}:{}.",
-                node.category(),
-                node.component_id(),
-                predecessor.category(),
-                predecessor.component_id()
-            ))
+            return Err(ValidationError::new(
+                format!(
+                    "{}:{} can't have any predecessors. Found {}:{}.",
+                    node.category(),
+                    node.component_id(),
+                    predecessor.category(),
+                    predecessor.component_id()
+                ),
+                [node.component_id(), predecessor.component_id()],
+            )
             .into());
         }
         Ok(())
@@ -64,14 +73,17 @@ where
     ) -> Result<(), Error> {
         for predecessor in self.cg.predecessors(node.component_id())? {
             if !predicate(predecessor) {
-                return Err(ValidationError::new(format!(
-                    "{}:{} can only have predecessors that are {}. Found {}:{}.",
-                    node.category(),
-                    node.component_id(),
-                    failure_message,
-                    predecessor.category(),
-                    predecessor.component_id()
-                ))
+                return Err(ValidationError::new(
+                    format!(
+                        "{}:{} can only have predecessors that are {}. Found {}:{}.",
+                        node.category(),
+                        node.component_id(),
+                        failure_message,
+                        predecessor.category(),
+                        predecessor.component_id()
+                    ),
+                    [node.component_id(), predecessor.component_id()],
+                )
                 .into());
             }
         }
@@ -87,14 +99,17 @@ where
     ) -> Result<(), Error> {
         for successor in self.cg.successors(node.component_id())? {
             if !predicate(successor) {
-                return Err(ValidationError::new(format!(
-                    "{}:{} can only have successors that are {}. Found {}:{}.",
-                    node.category(),
-                    node.component_id(),
-                    failure_message,
-                    successor.category(),
-                    successor.component_id()
-                ))
+                return Err(ValidationError::new(
+                    format!(
+                        "{}:{} can only have successors that are {}. Found {}:{}.",
+                        node.category(),
+                        node.component_id(),
+                        failure_message,
+                        successor.category(),
+                        successor.component_id()
+                    ),
+                    [node.component_id(), successor.component_id()],
+                )
                 .into());
             }
         }
@@ -108,13 +123,16 @@ where
     pub(super) fn ensure_exclusive_successors(&self, node: &N) -> Result<(), Error> {
         for successor in self.cg.successors(node.component_id())? {
             if self.cg.predecessors(successor.component_id())?.count() > 1 {
-                return Err(ValidationError::new(format!(
-                    "{}:{} can't have successors with multiple predecessors. Found {}:{}.",
-                    node.category(),
-                    node.component_id(),
-                    successor.category(),
-                    successor.component_id()
-                ))
+                return Err(ValidationError::new(
+                    format!(
+                        "{}:{} can't have successors with multiple predecessors. Found {}:{}.",
+                        node.category(),
+                        node.component_id(),
+                        successor.category(),
+                        successor.component_id()
+                    ),
+                    [node.component_id(), successor.component_id()],
+                )
                 .into());
             }
         }

--- a/src/graph/validation/validate_graph.rs
+++ b/src/graph/validation/validate_graph.rs
@@ -45,9 +45,10 @@ where
             .collect::<Vec<_>>();
 
         if !unvisited.is_empty() {
-            return Err(ValidationError::new(format!(
-                "Nodes {unvisited:?} are not connected to the root."
-            ))
+            return Err(ValidationError::new(
+                format!("Nodes {unvisited:?} are not connected to the root."),
+                unvisited,
+            )
             .into());
         }
 
@@ -71,15 +72,19 @@ where
                 .iter()
                 .position(|id| *id == successor.component_id())
             {
-                return Err(ValidationError::new(format!(
-                    "Cycle detected: {} -> {}",
-                    predecessors[first_occurrence..]
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<_>>()
-                        .join(" -> "),
-                    successor.component_id()
-                ))
+                let cycle = &predecessors[first_occurrence..];
+                return Err(ValidationError::new(
+                    format!(
+                        "Cycle detected: {} -> {}",
+                        cycle
+                            .iter()
+                            .map(|x| x.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" -> "),
+                        successor.component_id()
+                    ),
+                    cycle.to_vec(),
+                )
                 .into());
             }
             self.validate_acyclicity(successor, predecessors.clone())?;
@@ -142,7 +147,9 @@ mod tests {
         };
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Nodes [11] are not connected to the root.")),
+                .is_err_and(
+                    |e| e == validation_error("Nodes [11] are not connected to the root.", &[11])
+                ),
             "{err:?}"
         );
 
@@ -150,9 +157,11 @@ mod tests {
 
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(
-                    |e| e == validation_error("Nodes [11, 12] are not connected to the root.")
-                )
+                .is_err_and(|e| e
+                    == validation_error(
+                        "Nodes [11, 12] are not connected to the root.",
+                        &[11, 12]
+                    ))
         );
 
         connections.push(TestConnection::new(11, 12));
@@ -160,9 +169,11 @@ mod tests {
         // With the default config, this fails validation.
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(
-                    |e| e == validation_error("Nodes [11, 12] are not connected to the root.")
-                )
+                .is_err_and(|e| e
+                    == validation_error(
+                        "Nodes [11, 12] are not connected to the root.",
+                        &[11, 12]
+                    ))
         );
         // With `allow_unconnected_components=true`, this passes validation.
         assert!(
@@ -200,49 +211,54 @@ mod tests {
         connections.push(TestConnection::new(3, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 2")),
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 2", &[2, 3])),
         );
 
         connections.pop();
         connections.push(TestConnection::new(4, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 4 -> 2"))
+                .is_err_and(
+                    |e| e == validation_error("Cycle detected: 2 -> 3 -> 4 -> 2", &[2, 3, 4])
+                )
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 4 -> 5 -> 2"))
+                .is_err_and(|e| e
+                    == validation_error("Cycle detected: 2 -> 3 -> 4 -> 5 -> 2", &[2, 3, 4, 5]))
         );
 
         connections.pop();
         connections.push(TestConnection::new(4, 3));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 3 -> 4 -> 3"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 3 -> 4 -> 3", &[3, 4]))
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 3));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 3 -> 4 -> 5 -> 3"))
+                .is_err_and(
+                    |e| e == validation_error("Cycle detected: 3 -> 4 -> 5 -> 3", &[3, 4, 5])
+                )
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 4));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 4 -> 5 -> 4"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 4 -> 5 -> 4", &[4, 5]))
         );
 
         connections.pop();
         connections.push(TestConnection::new(9, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 9 -> 2"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 9 -> 2", &[2, 9]))
         );
 
         connections.pop();

--- a/src/graph/validation/validate_graph.rs
+++ b/src/graph/validation/validate_graph.rs
@@ -252,4 +252,25 @@ mod tests {
                 .is_ok()
         );
     }
+
+    /// A tolerated component-rule violation must not cancel out an
+    /// unconnected-component failure that is *not* tolerated: the checks'
+    /// outcomes are combined, not overwritten by whichever runs last.
+    #[test]
+    fn test_tolerated_failure_does_not_mask_a_fatal_one() {
+        let components = vec![
+            TestComponent::new(1, ComponentCategory::GridConnectionPoint),
+            TestComponent::new(2, ComponentCategory::Meter),
+            TestComponent::new(3, ComponentCategory::Battery(BatteryType::LiIon)),
+            // Node 4 is left unconnected, which is not tolerated by default.
+            TestComponent::new(4, ComponentCategory::Meter),
+        ];
+        // The meter -> battery edge breaks a neighbor rule, which *is* tolerated.
+        let connections = vec![TestConnection::new(1, 2), TestConnection::new(2, 3)];
+        let config = ComponentGraphConfig::builder()
+            .allow_component_validation_failures(true)
+            .build();
+
+        assert!(ComponentGraph::try_new(components, connections, config).is_err());
+    }
 }

--- a/src/graph/validation/validate_graph.rs
+++ b/src/graph/validation/validate_graph.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::{Edge, Error, Node};
+use crate::{Edge, Error, Node, ValidationError};
 
 use super::ComponentGraphValidator;
 
@@ -45,9 +45,10 @@ where
             .collect::<Vec<_>>();
 
         if !unvisited.is_empty() {
-            return Err(Error::invalid_graph(format!(
+            return Err(ValidationError::new(format!(
                 "Nodes {unvisited:?} are not connected to the root."
-            )));
+            ))
+            .into());
         }
 
         Ok(())
@@ -70,7 +71,7 @@ where
                 .iter()
                 .position(|id| *id == successor.component_id())
             {
-                return Err(Error::invalid_graph(format!(
+                return Err(ValidationError::new(format!(
                     "Cycle detected: {} -> {}",
                     predecessors[first_occurrence..]
                         .iter()
@@ -78,7 +79,8 @@ where
                         .collect::<Vec<_>>()
                         .join(" -> "),
                     successor.component_id()
-                )));
+                ))
+                .into());
             }
             self.validate_acyclicity(successor, predecessors.clone())?;
         }
@@ -88,13 +90,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::ComponentCategory;
     use crate::ComponentGraph;
     use crate::ComponentGraphConfig;
     use crate::InverterType;
     use crate::component_category::BatteryType;
-    use crate::graph::test_utils::{TestComponent, TestConnection};
+    use crate::graph::test_utils::{TestComponent, TestConnection, validation_error};
 
     fn nodes_and_edges() -> (Vec<TestComponent>, Vec<TestConnection>) {
         let components = vec![
@@ -141,9 +142,7 @@ mod tests {
         };
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(
-                    |e| e == Error::invalid_graph("Nodes [11] are not connected to the root.")
-                ),
+                .is_err_and(|e| e == validation_error("Nodes [11] are not connected to the root.")),
             "{err:?}"
         );
 
@@ -152,7 +151,7 @@ mod tests {
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(
-                    |e| e == Error::invalid_graph("Nodes [11, 12] are not connected to the root.")
+                    |e| e == validation_error("Nodes [11, 12] are not connected to the root.")
                 )
         );
 
@@ -162,7 +161,7 @@ mod tests {
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(
-                    |e| e == Error::invalid_graph("Nodes [11, 12] are not connected to the root.")
+                    |e| e == validation_error("Nodes [11, 12] are not connected to the root.")
                 )
         );
         // With `allow_unconnected_components=true`, this passes validation.
@@ -201,49 +200,49 @@ mod tests {
         connections.push(TestConnection::new(3, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 2 -> 3 -> 2")),
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 2")),
         );
 
         connections.pop();
         connections.push(TestConnection::new(4, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 2 -> 3 -> 4 -> 2"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 4 -> 2"))
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 2 -> 3 -> 4 -> 5 -> 2"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 3 -> 4 -> 5 -> 2"))
         );
 
         connections.pop();
         connections.push(TestConnection::new(4, 3));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 3 -> 4 -> 3"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 3 -> 4 -> 3"))
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 3));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 3 -> 4 -> 5 -> 3"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 3 -> 4 -> 5 -> 3"))
         );
 
         connections.pop();
         connections.push(TestConnection::new(5, 4));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 4 -> 5 -> 4"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 4 -> 5 -> 4"))
         );
 
         connections.pop();
         connections.push(TestConnection::new(9, 2));
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
-                .is_err_and(|e| e == Error::invalid_graph("Cycle detected: 2 -> 9 -> 2"))
+                .is_err_and(|e| e == validation_error("Cycle detected: 2 -> 9 -> 2"))
         );
 
         connections.pop();

--- a/src/graph/validation/validate_neighbors.rs
+++ b/src/graph/validation/validate_neighbors.rs
@@ -5,7 +5,8 @@
 //! connected correctly.
 
 use crate::{
-    ComponentCategory, Edge, Error, InverterType, Node, component_category::CategoryPredicates,
+    ComponentCategory, Edge, Error, InverterType, Node, ValidationError,
+    component_category::CategoryPredicates,
 };
 
 use super::ComponentGraphValidator;
@@ -80,10 +81,11 @@ where
                 }
                 InverterType::Unspecified => {
                     if !self.cg.config.allow_unspecified_inverters {
-                        return Err(Error::invalid_graph(format!(
+                        return Err(ValidationError::new(format!(
                             "Inverter {} has an unspecified inverter type.",
                             inverter.component_id()
-                        )));
+                        ))
+                        .into());
                     } else {
                         tracing::debug!(
                             concat!(
@@ -170,7 +172,7 @@ mod tests {
     use crate::InverterType;
     use crate::component_category::BatteryType;
     use crate::component_category::EvChargerType;
-    use crate::graph::test_utils::{TestComponent, TestConnection};
+    use crate::graph::test_utils::{TestComponent, TestConnection, validation_error};
 
     #[test]
     fn test_validate_root() {
@@ -189,7 +191,7 @@ mod tests {
         let connections: Vec<TestConnection> = vec![];
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == Error::invalid_graph("GridConnectionPoint:1 must have at least one successor.")
+                e == validation_error("GridConnectionPoint:1 must have at least one successor.")
             }),
         );
 
@@ -206,7 +208,7 @@ mod tests {
 
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == Error::invalid_graph(concat!(
+                e == validation_error(concat!(
                     "GridConnectionPoint:1 can't have successors with ",
                     "multiple predecessors. Found Meter:3."
                 ))
@@ -223,13 +225,24 @@ mod tests {
             TestComponent::new(3, ComponentCategory::Battery(BatteryType::LiIon)),
         ];
         let connections = vec![TestConnection::new(1, 2), TestConnection::new(2, 3)];
-        assert!(
-            ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e.to_string() ==
-r#"InvalidGraph: Multiple validation failures:
-    InvalidGraph: Meter:2 can only have successors that are not Batteries. Found Battery(LiIon):3.
-    InvalidGraph: Battery(LiIon):3 can only have predecessors that are BatteryInverters or HybridInverters. Found Meter:2."#
-            }));
+
+        let Err(error) = ComponentGraph::try_new(components, connections, config.clone()) else {
+            panic!("expected validation to fail");
+        };
+        // A single bad meter -> battery edge trips two neighbor rules, which are
+        // collected together rather than flattened into one string.
+        assert_eq!(
+            error,
+            Error::validation_errors(vec![
+                ValidationError::new(
+                    "Meter:2 can only have successors that are not Batteries. Found Battery(LiIon):3."
+                ),
+                ValidationError::new(concat!(
+                    "Battery(LiIon):3 can only have predecessors that are ",
+                    "BatteryInverters or HybridInverters. Found Meter:2."
+                )),
+            ]),
+        );
     }
 
     #[test]
@@ -252,11 +265,12 @@ r#"InvalidGraph: Multiple validation failures:
             panic!()
         };
         assert!(
-            ComponentGraph::try_new(components.clone(), connections.clone(), config.clone()).is_err_and(|e| {
-                e == Error::invalid_graph(
-                    "BatteryInverter:3 can only have successors that are Batteries. Found WindTurbine:4.",
-                )
-            }),
+            ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
+                .is_err_and(|e| {
+                    e == validation_error(
+                        "BatteryInverter:3 can only have successors that are Batteries. Found WindTurbine:4.",
+                    )
+                }),
             "{}",
             err
         );
@@ -267,7 +281,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph("BatteryInverter:3 must have at least one successor.")
+                    e == validation_error("BatteryInverter:3 must have at least one successor.")
                 }),
         );
 
@@ -298,7 +312,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(
+                    e == validation_error(
                         "PvInverter:3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
@@ -338,7 +352,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(concat!(
+                    e == validation_error(concat!(
                         "HybridInverter:3 can only have successors that are Batteries. ",
                         "Found WindTurbine:4."
                     ))
@@ -381,7 +395,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(
+                    e == validation_error(
                         "Battery(NaIon):4 can't have any successors. Found Battery(LiIon):5.",
                     )
                 }),
@@ -420,7 +434,7 @@ r#"InvalidGraph: Multiple validation failures:
 
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == Error::invalid_graph(concat!(
+                e == validation_error(concat!(
                     "Battery(LiIon):2 can only have predecessors that are ",
                     "BatteryInverters or HybridInverters. Found GridConnectionPoint:1."
                 ))
@@ -445,7 +459,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(
+                    e == validation_error(
                         "EVCharger(DC):3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),
@@ -474,9 +488,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(
-                        "CHP:3 can't have any successors. Found WindTurbine:4.",
-                    )
+                    e == validation_error("CHP:3 can't have any successors. Found WindTurbine:4.")
                 }),
         );
 
@@ -503,7 +515,7 @@ r#"InvalidGraph: Multiple validation failures:
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == Error::invalid_graph(
+                    e == validation_error(
                         "SteamBoiler:3 can't have any successors. Found WindTurbine:4.",
                     )
                 }),

--- a/src/graph/validation/validate_neighbors.rs
+++ b/src/graph/validation/validate_neighbors.rs
@@ -81,10 +81,13 @@ where
                 }
                 InverterType::Unspecified => {
                     if !self.cg.config.allow_unspecified_inverters {
-                        return Err(ValidationError::new(format!(
-                            "Inverter {} has an unspecified inverter type.",
-                            inverter.component_id()
-                        ))
+                        return Err(ValidationError::new(
+                            format!(
+                                "Inverter {} has an unspecified inverter type.",
+                                inverter.component_id()
+                            ),
+                            [inverter.component_id()],
+                        )
                         .into());
                     } else {
                         tracing::debug!(
@@ -191,7 +194,10 @@ mod tests {
         let connections: Vec<TestConnection> = vec![];
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == validation_error("GridConnectionPoint:1 must have at least one successor.")
+                e == validation_error(
+                    "GridConnectionPoint:1 must have at least one successor.",
+                    &[1],
+                )
             }),
         );
 
@@ -208,10 +214,13 @@ mod tests {
 
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == validation_error(concat!(
-                    "GridConnectionPoint:1 can't have successors with ",
-                    "multiple predecessors. Found Meter:3."
-                ))
+                e == validation_error(
+                    concat!(
+                        "GridConnectionPoint:1 can't have successors with ",
+                        "multiple predecessors. Found Meter:3."
+                    ),
+                    &[1, 3],
+                )
             }),
         );
     }
@@ -235,12 +244,16 @@ mod tests {
             error,
             Error::validation_errors(vec![
                 ValidationError::new(
-                    "Meter:2 can only have successors that are not Batteries. Found Battery(LiIon):3."
+                    "Meter:2 can only have successors that are not Batteries. Found Battery(LiIon):3.",
+                    [2, 3],
                 ),
-                ValidationError::new(concat!(
-                    "Battery(LiIon):3 can only have predecessors that are ",
-                    "BatteryInverters or HybridInverters. Found Meter:2."
-                )),
+                ValidationError::new(
+                    concat!(
+                        "Battery(LiIon):3 can only have predecessors that are ",
+                        "BatteryInverters or HybridInverters. Found Meter:2."
+                    ),
+                    [3, 2],
+                ),
             ]),
         );
     }
@@ -269,6 +282,7 @@ mod tests {
                 .is_err_and(|e| {
                     e == validation_error(
                         "BatteryInverter:3 can only have successors that are Batteries. Found WindTurbine:4.",
+                        &[3, 4],
                     )
                 }),
             "{}",
@@ -281,7 +295,10 @@ mod tests {
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == validation_error("BatteryInverter:3 must have at least one successor.")
+                    e == validation_error(
+                        "BatteryInverter:3 must have at least one successor.",
+                        &[3],
+                    )
                 }),
         );
 
@@ -314,6 +331,7 @@ mod tests {
                 .is_err_and(|e| {
                     e == validation_error(
                         "PvInverter:3 can't have any successors. Found WindTurbine:4.",
+                        &[3, 4],
                     )
                 }),
         );
@@ -352,10 +370,13 @@ mod tests {
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == validation_error(concat!(
-                        "HybridInverter:3 can only have successors that are Batteries. ",
-                        "Found WindTurbine:4."
-                    ))
+                    e == validation_error(
+                        concat!(
+                            "HybridInverter:3 can only have successors that are Batteries. ",
+                            "Found WindTurbine:4."
+                        ),
+                        &[3, 4],
+                    )
                 }),
         );
 
@@ -397,6 +418,7 @@ mod tests {
                 .is_err_and(|e| {
                     e == validation_error(
                         "Battery(NaIon):4 can't have any successors. Found Battery(LiIon):5.",
+                        &[4, 5],
                     )
                 }),
         );
@@ -434,10 +456,13 @@ mod tests {
 
         assert!(
             ComponentGraph::try_new(components, connections, config.clone()).is_err_and(|e| {
-                e == validation_error(concat!(
-                    "Battery(LiIon):2 can only have predecessors that are ",
-                    "BatteryInverters or HybridInverters. Found GridConnectionPoint:1."
-                ))
+                e == validation_error(
+                    concat!(
+                        "Battery(LiIon):2 can only have predecessors that are ",
+                        "BatteryInverters or HybridInverters. Found GridConnectionPoint:1."
+                    ),
+                    &[2, 1],
+                )
             }),
         );
     }
@@ -461,6 +486,7 @@ mod tests {
                 .is_err_and(|e| {
                     e == validation_error(
                         "EVCharger(DC):3 can't have any successors. Found WindTurbine:4.",
+                        &[3, 4],
                     )
                 }),
         );
@@ -488,7 +514,10 @@ mod tests {
         assert!(
             ComponentGraph::try_new(components.clone(), connections.clone(), config.clone())
                 .is_err_and(|e| {
-                    e == validation_error("CHP:3 can't have any successors. Found WindTurbine:4.")
+                    e == validation_error(
+                        "CHP:3 can't have any successors. Found WindTurbine:4.",
+                        &[3, 4],
+                    )
                 }),
         );
 
@@ -517,6 +546,7 @@ mod tests {
                 .is_err_and(|e| {
                     e == validation_error(
                         "SteamBoiler:3 can't have any successors. Found WindTurbine:4.",
+                        &[3, 4],
                     )
                 }),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod graph_traits;
 pub use graph_traits::{Edge, Node};
 
 mod error;
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 
 mod config;
 pub use config::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod graph_traits;
 pub use graph_traits::{Edge, Node};
 
 mod error;
-pub use error::{Error, ErrorKind};
+pub use error::{Error, ErrorKind, ValidationError};
 
 mod config;
 pub use config::{


### PR DESCRIPTION
Graph validation used to flatten all failures into a single `InvalidGraph` error string. This makes them structured and inspectable.

## Changes
- `ErrorKind` is now public (and `#[non_exhaustive]`), readable via `Error::kind()`.
- Validation failures are collected into `ErrorKind::ValidationErrors(Vec<ValidationError>)`. Each `ValidationError` exposes `message()` and the `component_ids()` it involves — neighbor-rule violations, unreachable nodes, or the nodes forming a cycle — so callers can act on the affected components without parsing strings.
- Fix a bug where a tolerated failure could mask a non-tolerated one (the fatal flag was overwritten instead of OR'd), which let an invalid graph build.

## Breaking
- Error `Display` changed: failures are listed under a `Graph validation failed:` header, without the old per-line `InvalidGraph:` prefixes.