### PR TITLE
Internal cleanups to the Expr printer and graph traversal

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,10 +38,10 @@ pub struct ComponentGraphConfig {
     /// Default policy for the per-category "component" formulas.
     ///
     /// When `true` (the default), the meter measurement is the primary
-    /// source and the device measurement is the fallback for the per-
+    /// source and the component measurement is the fallback for the per-
     /// category formulas (`battery_formula`, `chp_formula`, `pv_formula`,
     /// `wind_turbine_formula`, `ev_charger_formula`, `steam_boiler_formula`).
-    /// When `false`, the device is primary and the meter is the fallback.
+    /// When `false`, the component is primary and the meter is the fallback.
     ///
     /// Per-formula overrides live in [`formula_overrides`][Self::formula_overrides].
     ///
@@ -49,7 +49,7 @@ pub struct ComponentGraphConfig {
     /// `producer_formula`, or any of the coalesce formulas.
     pub(crate) prefer_meters_in_component_formulas: bool,
 
-    /// Per-formula overrides for the meter/device preference; see
+    /// Per-formula overrides for the meter/component preference; see
     /// [`FormulaOverrides`].
     pub(crate) formula_overrides: FormulaOverrides,
 }
@@ -189,7 +189,7 @@ impl ComponentGraphConfigBuilder {
         self
     }
 
-    /// Sets the global meter-vs-device source preference for the
+    /// Sets the global meter-vs-component source preference for the
     /// per-category formulas. See the field-level docs on
     /// [`ComponentGraphConfig`] for the exact list of affected formulas.
     pub fn prefer_meters_in_component_formulas(mut self, value: bool) -> Self {
@@ -197,7 +197,7 @@ impl ComponentGraphConfigBuilder {
         self
     }
 
-    /// Sets the per-formula overrides for the meter/device preference.
+    /// Sets the per-formula overrides for the meter/component preference.
     /// Each override, when `Some(_)`, takes precedence over
     /// [`prefer_meters_in_component_formulas`][Self::prefer_meters_in_component_formulas]
     /// for that formula.
@@ -212,14 +212,14 @@ impl ComponentGraphConfigBuilder {
     }
 }
 
-/// Per-formula overrides for the meter/device preference in the
+/// Per-formula overrides for the meter/component preference in the
 /// per-category formulas.
 ///
 /// Each field is `None` by default, meaning the corresponding formula
 /// follows the global `prefer_meters_in_component_formulas` setting on
 /// [`ComponentGraphConfig`]. Setting an entry to `Some(true)` forces
 /// the meter as primary for that formula; `Some(false)` forces the
-/// device.
+/// component.
 ///
 /// Construct via [`FormulaOverrides::builder`] or
 /// [`FormulaOverrides::default`].
@@ -255,7 +255,7 @@ impl FormulaOverridesBuilder {
         }
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::pv_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::pv_formula
@@ -264,7 +264,7 @@ impl FormulaOverridesBuilder {
         self
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::battery_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::battery_formula
@@ -273,7 +273,7 @@ impl FormulaOverridesBuilder {
         self
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::chp_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::chp_formula
@@ -282,7 +282,7 @@ impl FormulaOverridesBuilder {
         self
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::ev_charger_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::ev_charger_formula
@@ -291,7 +291,7 @@ impl FormulaOverridesBuilder {
         self
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::wind_turbine_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::wind_turbine_formula
@@ -300,7 +300,7 @@ impl FormulaOverridesBuilder {
         self
     }
 
-    /// Override the meter/device preference for
+    /// Override the meter/component preference for
     /// [`ComponentGraph::steam_boiler_formula`][cg].
     ///
     /// [cg]: crate::ComponentGraph::steam_boiler_formula

--- a/src/graph/formulas/expr.rs
+++ b/src/graph/formulas/expr.rs
@@ -243,35 +243,25 @@ impl Expr {
 
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.generate_string(false))
+        write!(f, "{}", self.render())
     }
 }
 
-/// Specifies how to add brackets when generating a string representation of an
-/// expression.
+/// Display helpers for `Expr`.
 ///
-/// - `First`: Add brackets around the first component.
-/// - `Rest`: Add brackets around all components except the first.
-/// - `All`: Add brackets around all components.
-/// - `None`: Do not add brackets.
-#[derive(PartialEq)]
-enum BracketComponents {
-    First,
-    Rest,
-    All,
-    None,
-}
-
-/// Display helpers for `FormulaExpression`.
+/// Bracketing is precedence-based: only an *additive* expression (`Add` / `Sub`)
+/// can be ambiguous in context, and only in two positions — as the operand of a
+/// negation (`-(a + b)`) or as a non-first operand of a subtraction
+/// (`a - (b + c)`). Everywhere else (additions, the first term of a
+/// subtraction, and the comma-separated arguments of `COALESCE` / `MIN` /
+/// `MAX`) an additive child renders without brackets, because `a + b - c`
+/// already parses as `a + (b - c)`.
 impl Expr {
-    /// Generates a string representation of the expression.
-    ///
-    /// If `bracket_whole` is `true` and the expression has more than one
-    /// component, the whole expression is enclosed in brackets.
-    fn generate_string(&self, bracket_whole: bool) -> String {
+    /// Renders the expression as a formula string.
+    fn render(&self) -> String {
         match self {
             Self::None => String::from("None"),
-            Self::Neg { param } => format!("-{}", param.generate_string(true)),
+            Self::Neg { param } => format!("-{}", param.render_grouped()),
             Self::Number { value } => {
                 if value.fract() == 0.0 {
                     // For whole numbers, format with one decimal place.
@@ -282,63 +272,44 @@ impl Expr {
                 }
             }
             Self::Component { component_id } => format!("#{component_id}"),
-            Self::Add { params } => {
-                Self::join_params(params, " + ", None, BracketComponents::None, bracket_whole)
-            }
-            Self::Sub { params } => {
-                Self::join_params(params, " - ", None, BracketComponents::Rest, bracket_whole)
-            }
-            Self::Coalesce { params } => Self::join_params(
-                params,
-                ", ",
-                Some("COALESCE"),
-                BracketComponents::None,
-                false,
-            ),
-            Self::Min { params } => {
-                Self::join_params(params, ", ", Some("MIN"), BracketComponents::None, false)
-            }
-            Self::Max { params } => {
-                Self::join_params(params, ", ", Some("MAX"), BracketComponents::None, false)
-            }
+            Self::Add { params } => Self::join(params, " + "),
+            Self::Sub { params } => match params.split_first() {
+                Some((first, rest)) => {
+                    let mut result = first.render();
+                    for param in rest {
+                        result.push_str(" - ");
+                        result.push_str(&param.render_grouped());
+                    }
+                    result
+                }
+                None => String::new(),
+            },
+            Self::Coalesce { params } => format!("COALESCE({})", Self::join(params, ", ")),
+            Self::Min { params } => format!("MIN({})", Self::join(params, ", ")),
+            Self::Max { params } => format!("MAX({})", Self::join(params, ", ")),
         }
     }
 
-    /// Joins a list of expressions into a string, with the specified separator.
-    ///
-    /// It also takes an optional prefix, and specifics on how to bracket the
-    /// components and the whole expression.
-    fn join_params(
-        params: &[Expr],
-        separator: &str,
-        prefix: Option<&str>,
-        bracket_components: BracketComponents,
-        bracket_whole: bool,
-    ) -> String {
-        let (mut result, suffix) = match prefix {
-            Some(prefix) => (format!("{prefix}("), String::from(")")),
-            None => (String::new(), String::new()),
-        };
-        let mut num_components = 0;
-        for expression in params.iter() {
-            if num_components > 0 {
-                result.push_str(separator);
+    /// Renders the expression, wrapping it in brackets when it is additive (so
+    /// it can be safely placed after a `-`).
+    fn render_grouped(&self) -> String {
+        match self {
+            // A single-term additive expression renders like its sole term, so
+            // it needs no brackets (matches the previous printer's behaviour).
+            Self::Add { params } | Self::Sub { params } if params.len() > 1 => {
+                format!("({})", self.render())
             }
-            if (bracket_components == BracketComponents::First && num_components == 0)
-                || (bracket_components == BracketComponents::Rest && num_components > 0)
-                || (bracket_components == BracketComponents::All)
-            {
-                result.push_str(&expression.generate_string(true));
-            } else {
-                result.push_str(&expression.generate_string(false));
-            }
-            num_components += 1;
+            _ => self.render(),
         }
-        if bracket_whole && num_components > 1 {
-            String::from("(") + &result + &suffix + ")"
-        } else {
-            result + &suffix
-        }
+    }
+
+    /// Renders and joins the given expressions with `separator`.
+    fn join(params: &[Expr], separator: &str) -> String {
+        params
+            .iter()
+            .map(Self::render)
+            .collect::<Vec<_>>()
+            .join(separator)
     }
 }
 

--- a/src/graph/formulas/expr.rs
+++ b/src/graph/formulas/expr.rs
@@ -109,7 +109,9 @@ impl std::ops::Neg for Expr {
             Expr::Neg { param: inner } => *inner,
             // -(a - b) = b - a
             // -(a - b - c) = b + c - a
-            Expr::Sub { mut params } => {
+            // (`Sub` always has at least two operands by construction; the guard
+            // keeps `remove(0)` from panicking should that ever change.)
+            Expr::Sub { mut params } if !params.is_empty() => {
                 let first = params.remove(0);
                 Expr::Add { params } - first
             }

--- a/src/graph/retrieval.rs
+++ b/src/graph/retrieval.rs
@@ -188,7 +188,7 @@ where
     pub(crate) fn find_all(
         &self,
         from: u64,
-        mut pred: impl FnMut(&N) -> bool,
+        pred: impl Fn(&N) -> bool,
         direction: petgraph::Direction,
         follow_after_match: bool,
     ) -> Result<BTreeSet<u64>, Error> {
@@ -196,9 +196,16 @@ where
             Error::component_not_found(format!("Component with id {from} not found."))
         })?;
         let mut stack = vec![*index];
+        let mut visited = HashSet::new();
         let mut found = BTreeSet::new();
 
         while let Some(index) = stack.pop() {
+            // Skip nodes already expanded: a DAG with diamonds reaches the
+            // same node by multiple paths, and re-expanding it is redundant
+            // (and exponential on chained diamonds).
+            if !visited.insert(index) {
+                continue;
+            }
             let node = &self.graph[index];
             // Pass-through nodes are transparent: skip the predicate
             // check but follow through their neighbors.
@@ -596,6 +603,63 @@ mod tests {
 
         let found = graph.find_all(3, |_| true, petgraph::Direction::Outgoing, true)?;
         assert_eq!(found, [3, 4, 5].iter().cloned().collect());
+
+        Ok(())
+    }
+
+    /// `find_all` deduplicates on a re-converging (diamond) topology: a node
+    /// reachable by two paths is expanded once, not once per path. This is the
+    /// shape the `visited` set guards — the tree topologies above never exercise
+    /// it. `follow_after_match = true` is the case that actually re-expands (a
+    /// matched node keeps expanding), so the diamond apex and its subtree must
+    /// still appear exactly once.
+    ///
+    /// Topology (ids): `Grid:0 → {Meter:1, Meter:2}`, both `→ Inverter:3 → Battery:4`.
+    #[test]
+    fn test_find_all_dedups_on_diamond() -> Result<(), Error> {
+        let mut builder = ComponentGraphBuilder::new();
+        let grid = builder.grid();
+        let meter_a = builder.meter();
+        let meter_b = builder.meter();
+        let inverter = builder.battery_inverter();
+        let battery = builder.battery();
+
+        builder.connect(grid, meter_a);
+        builder.connect(grid, meter_b);
+        // The inverter is the diamond apex: reachable via both meters.
+        builder.connect(meter_a, inverter);
+        builder.connect(meter_b, inverter);
+        builder.connect(inverter, battery);
+
+        let graph = builder.build(None)?;
+
+        // follow_after_match = true: the inverter matches yet keeps expanding, and
+        // it is reached by both meters — it and its battery must appear once each.
+        let found = graph.find_all(
+            grid.component_id(),
+            |n| !n.is_grid(),
+            petgraph::Direction::Outgoing,
+            true,
+        )?;
+        assert_eq!(
+            found,
+            BTreeSet::from([
+                meter_a.component_id(),
+                meter_b.component_id(),
+                inverter.component_id(),
+                battery.component_id(),
+            ])
+        );
+
+        // A predicate matching only the apex's subtree still reaches it through
+        // the diamond — the apex is expanded, not skipped before its successors.
+        let found = graph.find_all(
+            grid.component_id(),
+            |n| n.is_battery(),
+            petgraph::Direction::Outgoing,
+            true,
+        )?;
+        assert_eq!(found, BTreeSet::from([battery.component_id()]));
 
         Ok(())
     }


### PR DESCRIPTION
A handful of independent, output-preserving internal cleanups to the formula engine and graph traversal.

## Changes

- Render `Expr` with a precedence-based printer: replace the `BracketComponents` enum and the `bracket_components`/`bracket_whole` threading in `generate_string`/`join_params` with a local rule — an additive expression is bracketed only as a negation operand or a non-first subtraction operand. Drops the dead `First`/`All` variants; identical output.
- Add a visited set to `find_all` (it re-expanded a node once per path — exponential on chained diamonds) and tighten its predicate from `FnMut` to `Fn`. The result is a `BTreeSet`, so output is unchanged.
- Guard `Neg` against an empty `Sub` so `params.remove(0)` can't panic (defensive; `Sub` always has ≥2 operands by construction).
- Rename "device" → "component" in the config doc comments ("component" is our term).

All `pub(crate)`/private/doc-only — no public API or behavior change.